### PR TITLE
Refactoring of Maybe

### DIFF
--- a/src/Basics.ts
+++ b/src/Basics.ts
@@ -1,15 +1,25 @@
+export type Arg<F> = F extends (arg: infer A) => unknown ? A : never;
+
+export type Return<F> = F extends (...args: Array<unknown>) => infer R ? R : never;
+
+export type Optional<O extends object> = {[ K in keyof O ]?: O[ K ]};
+
+export type Compute<A> = A extends infer O ? {
+    [ K in keyof O ]: O[ K ];
+} : never;
+
 export type IsNever<A, T, F> = [ A ] extends [ never ] ? T : F;
 
 export type WhenNever<A, T> = [ A, T ] extends [ T, A ] ? A : IsNever<A, T, A>;
 
-type Combinations<T> =  {
-    [ K in keyof T ]: {
-        [ N in keyof T ]?: N extends K ? never : T[ N ];
-    };
-}[ keyof T ];
-
-export type Cata<T>
-    = T extends {[ K in keyof T ]: (...args: Array<unknown>) => infer R }
-    ? T & { _?: never } | Combinations<T> & { _(): R }
-    : T
+export type Cata<O extends {[ K in keyof O ]: (...args: Array<unknown>) => unknown } & { _?: never }>
+    = O extends {[ K in keyof O ]: (...args: Array<unknown>) => infer R }
+    ? Compute<O & { _?(): never }> | Compute<Optional<O> & { _(): R }>
+    : never
     ;
+
+export const inst = <T>(Constructor: new () => T) => new Constructor();
+
+export const cons = <A extends Array<unknown>, T>(
+    Constructor: new (...args: A) => A extends [] ? never : T
+) => (...args: A): T => new Constructor(...args);

--- a/src/Either.ts
+++ b/src/Either.ts
@@ -2,11 +2,7 @@ import {
     WhenNever,
     Cata
 } from './Basics';
-import {
-    Maybe,
-    Nothing,
-    Just
-} from './Maybe';
+import Maybe, { Nothing, Just } from './Maybe';
 
 export type Pattern<E, T, R> = Cata<{
     Left(error: E): R;

--- a/src/Http.ts
+++ b/src/Http.ts
@@ -1,11 +1,7 @@
 import {
     Cata
 } from './Basics';
-import {
-    Maybe,
-    Nothing,
-    Just
-} from './Maybe';
+import Maybe, { Nothing, Just } from './Maybe';
 import {
     Either,
     Right

--- a/src/Json/Decode.ts
+++ b/src/Json/Decode.ts
@@ -1,11 +1,7 @@
 import {
     Cata
 } from '../Basics';
-import {
-    Maybe,
-    Nothing,
-    Just
-} from '../Maybe';
+import Maybe, { Nothing, Just } from '../Maybe';
 import {
     Either,
     Left,

--- a/src/Json/Encode.ts
+++ b/src/Json/Encode.ts
@@ -1,6 +1,4 @@
-import {
-    Maybe
-} from '../Maybe';
+import Maybe from '../Maybe';
 
 interface ValueArray extends Array<Value> {}
 

--- a/src/Maybe.ts
+++ b/src/Maybe.ts
@@ -22,6 +22,9 @@ export namespace Maybe {
 
 export type Pattern<T, R> = Maybe.Pattern<T, R>;
 
+/**
+ *
+ */
 export interface Maybe<T> {
     isNothing(): boolean;
     isJust(): boolean;
@@ -37,6 +40,7 @@ export interface Maybe<T> {
     getOrElse<D>(defaults: WhenNever<T, D>): WhenNever<T, D>;
     fold<R>(onNothing: () => R, onJust: (value: T) => R): R;
     cata<R>(pattern: Pattern<T, R>): R;
+    touch<R>(fn: (that: Maybe<T>) => R): R;
 
     toEither<E>(error: E): Either<E, T>;
 }
@@ -93,6 +97,10 @@ namespace MaybeVariants {
             }
 
             return (pattern._ as () => R)();
+        }
+
+        public touch<T, R>(fn: (that: Maybe<T>) => R): R {
+            return fn(this);
         }
 
         public toEither<E, T>(error: E): Either<E, T> {
@@ -156,6 +164,10 @@ namespace MaybeVariants {
             }
 
             return (pattern._ as () => R)();
+        }
+
+        public touch<R>(fn: (that: Maybe<T>) => R): R {
+            return fn(this);
         }
 
         public toEither<E>(): Either<E, T> {

--- a/src/Maybe.ts
+++ b/src/Maybe.ts
@@ -183,7 +183,7 @@ export const props = <O extends object>(config: {[ K in keyof O ]: Maybe<O[ K ]>
     return Just(acc);
 };
 
-export const list = <T>(array: Array<Maybe<T>>): Maybe<Array<T>> => {
+export const combine = <T>(array: Array<Maybe<T>>): Maybe<Array<T>> => {
     const acc: Array<T> = [];
 
     for (const item of array) {
@@ -201,7 +201,7 @@ export const Maybe = {
     fromNullable,
     fromEither,
     props,
-    list,
+    combine,
     Nothing,
     Just
 };

--- a/src/Maybe.ts
+++ b/src/Maybe.ts
@@ -188,6 +188,10 @@ export const fromEither = <E, T>(either: Either<E, T>): Maybe<T> => {
     return either.map(Just).getOrElse(Nothing);
 };
 
+export const join = <T>(maybe: Maybe<Maybe<T>>): Maybe<T> => {
+    return maybe.chain((nested: Maybe<T>): Maybe<T> => nested);
+};
+
 export const props = <O extends object>(config: {[ K in keyof O ]: Maybe<O[ K ]>}): Maybe<O> => {
     const acc: O = {} as O;
 
@@ -235,6 +239,7 @@ export const Maybe = {
     Just,
     fromNullable,
     fromEither,
+    join,
     props,
     combine,
     values

--- a/src/Maybe.ts
+++ b/src/Maybe.ts
@@ -206,13 +206,26 @@ export const combine = <T>(array: Array<Maybe<T>>): Maybe<Array<T>> => {
     return Just(acc);
 };
 
+export const values = <T>(array: Array<Maybe<T>>): Array<T> => {
+    const acc: Array<T> = [];
+
+    for (const item of array) {
+        if (item.isJust()) {
+            acc.push(item.getOrElse(null as never));
+        }
+    }
+
+    return acc;
+};
+
 export const Maybe = {
+    Nothing,
+    Just,
     fromNullable,
     fromEither,
     props,
     combine,
-    Nothing,
-    Just
+    values
 };
 
 export default Maybe;

--- a/src/Maybe.ts
+++ b/src/Maybe.ts
@@ -168,37 +168,33 @@ export const fromEither = <E, T>(either: Either<E, T>): Maybe<T> => {
 };
 
 export const props = <O extends object>(config: {[ K in keyof O ]: Maybe<O[ K ]>}): Maybe<O> => {
-    let acc: Maybe<O> = Just({} as O);
+    const acc: O = {} as O;
 
     for (const key in config) {
         if (config.hasOwnProperty(key)) {
-            acc = acc.chain((obj: O): Maybe<O> => {
-                return config[ key ].map((value: O[ Extract<keyof O, string> ]): O => {
-                    obj[ key ] = value;
+            if (config[ key ].isNothing()) {
+                return Nothing;
+            }
 
-                    return obj;
-                });
-            });
+            acc[ key ] = config[ key ].getOrElse(null as never);
         }
     }
 
-    return acc;
+    return Just(acc);
 };
 
 export const list = <T>(array: Array<Maybe<T>>): Maybe<Array<T>> => {
-    let acc: Maybe<Array<T>> = Just([]);
+    const acc: Array<T> = [];
 
     for (const item of array) {
-        acc = acc.chain((arr: Array<T>): Maybe<Array<T>> => {
-            return item.map((value: T): Array<T> => {
-                arr.push(value);
+        if (item.isNothing()) {
+            return Nothing;
+        }
 
-                return arr;
-            });
-        });
+        acc.push(item.getOrElse(null as never));
     }
 
-    return acc;
+    return Just(acc);
 };
 
 export const Maybe = {

--- a/src/Maybe.ts
+++ b/src/Maybe.ts
@@ -29,6 +29,7 @@ export interface Maybe<T> {
 
     map<R>(fn: (value: T) => R): Maybe<R>;
     chain<R>(fn: (value: T) => Maybe<R>): Maybe<R>;
+    filter(fn: (value: T) => boolean): Maybe<T>;
     ap<R>(maybeFn: Maybe<(value: T) => R>): Maybe<R>;
     pipe(maybe: Wrap<Arg<T>>): Maybe<Return<T>>;
     orElse<D>(fn: () => Maybe<WhenNever<T, D>>): Maybe<WhenNever<T, D>>;
@@ -59,6 +60,10 @@ namespace MaybeVariants {
         }
 
         public chain<R>(): Maybe<R> {
+            return this;
+        }
+
+        public filter<T>(): Maybe<T> {
             return this;
         }
 
@@ -119,6 +124,10 @@ namespace MaybeVariants {
 
         public chain<R>(fn: (value: T) => Maybe<R>): Maybe<R> {
             return fn(this.value);
+        }
+
+        public filter(fn: (value: T) => boolean): Maybe<T> {
+            return fn(this.value) ? this : Nothing;
         }
 
         public ap<R>(maybeFn: Maybe<(value: T) => R>): Maybe<R> {

--- a/src/Maybe.ts
+++ b/src/Maybe.ts
@@ -23,6 +23,9 @@ export namespace Maybe {
     }>;
 }
 
+/**
+ * Pattern for matching the `Maybe` variants.
+ */
 export type Pattern<T, R> = Maybe.Pattern<T, R>;
 
 /**
@@ -35,11 +38,8 @@ export interface Maybe<T> {
      * Conveniently check if a `Maybe` matches `Nothing`.
      *
      * @example
-     * Just(42).isNothing() == false
-     *
-     * Just([]).isNothing() == false
-     *
-     * Nothing.isNothing() == true
+     * Nothing.isNothing()  // true
+     * Just(42).isNothing() // false
      */
     isNothing(): boolean;
 
@@ -47,11 +47,8 @@ export interface Maybe<T> {
      * Conveniently check if a `Maybe` matches `Just<any>`.
      *
      * @example
-     * Just(42).isJust() == true
-     *
-     * Just([]).isJust() == true
-     *
-     * Nothing.isJust() == false
+     * Nothing.isJust()  // false
+     * Just(42).isJust() // true
      */
     isJust(): boolean;
 
@@ -59,32 +56,173 @@ export interface Maybe<T> {
      * Check if the `Maybe` equals to another `Maybe`.
      *
      * @param another `Maybe` to check equality.
+     *
+     * @example
+     * Nothing.isEqual(Nothing)   // true
+     * Nothing.isEqual(Just(42))  // false
+     * Just(42).isEqual(Nothing)  // false
+     * Just(42).isEqual(Just(13)) // false
+     * Just(42).isEqual(Just(42)) // true
      */
     isEqual<D>(another: Maybe<WhenNever<T, D>>): boolean;
 
     /**
      * Transform the `Maybe` value with a given function.
      *
-     * @param fn transforming function.
+     * @param fn Transforming function.
+     *
+     * @example
+     * Nohting.map((a: number) => a * 2) // Nothing
+     * Just(3).map((a: number) => a * 2) // Just(6)
      */
     map<R>(fn: (value: T) => R): Maybe<R>;
 
     /**
      * Chain together many computations that may fail.
      *
-     * @param fn chaining function.
+     * @param fn Chaining function.
+     *
+     * @example
+     * Nothing.chain((a: number) => a > 0 ? Just(a * 2) : Nothing)  // Nothing
+     * Just(3).chain((a: number) => a > 0 ? Just(a * 2) : Nothing)  // Just(6)
+     * Just(-3).chain((a: number) => a > 0 ? Just(a * 2) : Nothing) // Nothing
      */
     chain<R>(fn: (value: T) => Maybe<R>): Maybe<R>;
+
+    /**
+     * Transorm the `Maybe` into Nothing when filter returns `false`
+     * otherwise keep the original `Maybe`.
+     *
+     * @param fn Filter function.
+     *
+     * @example
+     * Nothing.filter((a: number) => a > 0)   // Nothing
+     * Just(42).filter((a: number) => a > 0)  // Just(42)
+     * Just(-42).filter((a: number) => a > 0) // Nothing
+     */
     filter(fn: (value: T) => boolean): Maybe<T>;
+
+    /**
+     * Apply a `maybeFn` function to the `Maybe` value.
+     *
+     * @param maybeFn `Maybe` function.
+     *
+     * @example
+     * Nothing.ap(Nothing)                    // Nothing
+     * Just(3).ap(Nothing)                    // Nothing
+     * Nothing.ap(Just((a: number) => a * 2)) // Nothing
+     * Just(3).ap(Just((a: number) => a * 2)) // Just(6)
+     */
     ap<R>(maybeFn: Maybe<(value: T) => R>): Maybe<R>;
+
+    /**
+     * Apply a `maybe` value into the inner function.
+     *
+     * @param maybe `Maybe` value to apply.
+     *
+     * @example
+     * Just((a: number) => (b: boolean) => b ? 0 a * s)
+     *     .pipe(Just(42))
+     *     .pipe(Nothing)
+     *     // Nothing
+     *
+     * Just((a: number) => (b: boolean) => b ? 0 : a * 2)
+     *     .pipe(Just(3))
+     *     .pipe(Just(true))
+     *     // Just(6)
+     */
     pipe(maybe: Wrap<Arg<T>>): Maybe<Return<T>>;
+
+    /**
+     * Like the boolean `||` this will return the first value that is `Just`.
+     *
+     * @param fn The function to return next `Maybe`.
+     *
+     * @example
+     * Nothing.orElse(() => Nothing)   // Nothing
+     * Nothing.orElse(() => Just(42))  // Just(42)
+     * Just(13).orElse(() => Nothing)  // Just(13)
+     * Just(13).orElse(() => Just(42)) // Just(13)
+     */
     orElse<D>(fn: () => Maybe<WhenNever<T, D>>): Maybe<WhenNever<T, D>>;
 
+    /**
+     * Provide a `default` value, turning an optional value into a normal value.
+     *
+     * @param defaults The default `T`.
+     *
+     * @example
+     * Nothing.getOrElse(42)  // 42
+     * Just(13).getOrElse(42) // 13
+     */
     getOrElse<D>(defaults: WhenNever<T, D>): WhenNever<T, D>;
+
+    /**
+     * Fold the current `Maybe` according variant.
+     *
+     * @param onNothing The function calls in `Nothing` case.
+     * @param onJust    The function calls in `Just` case.
+     *
+     * @example
+     * Nothing.fold(() => 0, (a: number) => a * 2) // 0
+     * Just(3).fold(() => 0, (a: number) => a * 2) // 6
+     */
     fold<R>(onNothing: () => R, onJust: (value: T) => R): R;
+
+    /**
+     * Match the current `Maybe` to provided pattern.
+     *
+     * @param pattern Pattern matching.
+     *
+     * @example
+     * Nothing.cata({
+     *     Nothing: () => 0,
+     *     Just: (a: number) => a * 2
+     * }) // 0
+     *
+     * Just(3).cata({
+     *     Nothing: () => 0,
+     *     Just: (a: number) => a * 2
+     * }) // 6
+     */
     cata<R>(pattern: Pattern<T, R>): R;
+
+    /**
+     * Apply the current `Maybe` to the predicate function.
+     * Could be usefull to make code more "linear".
+     *
+     * @param fn Predicate function.
+     *
+     * @example
+     * const helperFunction = (maybeNumber: Maybe<number>): number => {
+     *     return maybeNumber
+     *         .chain((a: number) => a < 100 ? Just(a) : Nothing)
+     *         .map((a: number) => a * a)
+     *         .getOrElse(100)
+     * };
+     *
+     * Just(42)
+     *     .chain((a: number) => a > 0 ? Just(42 / 2) : Nothing)
+     *     .touch(helperFunction)
+     *     .toFixed(2)
+     *
+     * // equals to
+     *
+     * helperFunction(
+     *     Just(42).chain((a: number) => a > 0 ? Just(42 / 2) : Nothing)
+     * ).toFixed(2)
+     */
     touch<R>(fn: (that: Maybe<T>) => R): R;
 
+    /**
+     * Convert to `Either`.
+     *
+     * @param error `Left` error when `Nothing`.
+     *
+     * @example
+     * Nothing.toEither('error')  // Left('error')
+     * Just(42).toEither('error') // Right(42)
+     */
     toEither<E>(error: E): Either<E, T>;
 }
 
@@ -219,22 +357,81 @@ namespace MaybeVariants {
     }
 }
 
+/**
+ * Represents a `Maybe` containing no value.
+ */
 export const Nothing: Maybe<never> = new MaybeVariants.Nohting();
 
+/**
+ * Constructs a `Maybe` containing the `value`.
+ *
+ * @param value The `Maybe` value.
+ */
 export const Just = <T>(value: T): Maybe<T> => new MaybeVariants.Just(value);
 
+/**
+ * Converts nullable `value` into `Maybe`.
+ * `null` and `undefined` become `Nothing` otherwise `Just(value)`
+ *
+ * @param value Nullable value.
+ *
+ * @example
+ * fromNullable(null)                   // Nothing
+ * fromNullable([ '0', '1', '2' ][ 3 ]) // Nothing
+ * fromNullable([ '0', '1', '2' ][ 0 ]) // Just('0')
+ */
 export const fromNullable = <T>(value: T | null | undefined): Maybe<T extends null | undefined ? never : T> => {
     return value == null ? Nothing : Just(value as T extends null | undefined ? never : T);
 };
 
+/**
+ * Converts `Either` to `Maybe`.
+ * `Left` becomes `Nothing`, `Reight(value)` becomes `Just(value)`.
+ *
+ * @param either Converted `Either`
+ *
+ * @example
+ * fromEither(Left('error')) // Nothing
+ * fromEither(Right(42))     // Just(42)
+ */
 export const fromEither = <E, T>(either: Either<E, T>): Maybe<T> => {
     return either.map(Just).getOrElse(Nothing);
 };
 
+/**
+ * Flattens nested `Maybe`s.
+ *
+ * @param maybe `Maybe` with `Maybe` inside.
+ *
+ * @example
+ * join(Nothing)        // Nothing
+ * join(Just(Nothing))  // Nothing
+ * join(Just(Just(42))) // Just(42)
+ *
+ * Nothing.touch(join)              // Nothing
+ * Just(42).touch(Just).touch(join) // Just(42)
+ */
 export const join = <T>(maybe: Maybe<Maybe<T>>): Maybe<T> => {
     return maybe.chain((nested: Maybe<T>): Maybe<T> => nested);
 };
 
+/**
+ * Take an object of `Maybe`s and return a `Maybe` with an object of values.
+ * Returns `Nothing` if at least one of the fields is `Nothing`.
+ *
+ * @param config Object of `Maybe`s.
+ *
+ * @example
+ * props({
+ *     id: Just(0),
+ *     title: Nothing
+ * }) // Nothing
+ *
+ * props({
+ *     id: Just(0),
+ *     title: Just('name')
+ * }) // Just({ id: 0, title: 'name' })
+ */
 export const props = <O extends object>(config: {[ K in keyof O ]: Maybe<O[ K ]>}): Maybe<O> => {
     const acc: O = {} as O;
 
@@ -244,13 +441,23 @@ export const props = <O extends object>(config: {[ K in keyof O ]: Maybe<O[ K ]>
                 return Nothing;
             }
 
-            acc[ key ] = config[ key ].getOrElse(null as never);
+            acc[ key ] = config[ key ].getOrElse(null as never /* don't use this hack */);
         }
     }
 
     return Just(acc);
 };
 
+/**
+ * Take an array of `Maybe`s and return a `Maybe` with an array of values.
+ * Returns `Nothing` if at least one of the items is `Nothing`.
+ *
+ * @param array Array of `Maybe`s.
+ *
+ * @example
+ * combine([ Nothing, Just(42) ]) // Nothing
+ * combine([ Just(1), Just(2) ])  // Just([ 1, 2 ])
+ */
 export const combine = <T>(array: Array<Maybe<T>>): Maybe<Array<T>> => {
     const acc: Array<T> = [];
 
@@ -259,18 +466,27 @@ export const combine = <T>(array: Array<Maybe<T>>): Maybe<Array<T>> => {
             return Nothing;
         }
 
-        acc.push(item.getOrElse(null as never));
+        acc.push(item.getOrElse(null as never /* don't use this hack */));
     }
 
     return Just(acc);
 };
 
+/**
+ * Convert a list of `Maybe`s a to a list of a only for the values different from `Nothing`.
+ *
+ * @param array Array of `Maybe`s.
+ *
+ * @example
+ * combine([ Nothing, Just(42), Just(0) ]) // [ 42, 0 ]
+ * combine([ Just(1), Just(2), Nothing ])  // [ 1, 2 ]
+ */
 export const values = <T>(array: Array<Maybe<T>>): Array<T> => {
     const acc: Array<T> = [];
 
     for (const item of array) {
         if (item.isJust()) {
-            acc.push(item.getOrElse(null as never));
+            acc.push(item.getOrElse(null as never /* don't use this hack */));
         }
     }
 

--- a/src/Maybe.ts
+++ b/src/Maybe.ts
@@ -14,6 +14,9 @@ import {
 type Wrap<T> = IsNever<T, never, Maybe<T>>;
 
 export namespace Maybe {
+    /**
+     * Pattern for matching the `Maybe` variants.
+     */
     export type Pattern<T, R> = Cata<{
         Nothing(): R;
         Just(value: T): R;
@@ -23,14 +26,54 @@ export namespace Maybe {
 export type Pattern<T, R> = Maybe.Pattern<T, R>;
 
 /**
- *
+ * A data structure that models the presence or absence of a value.
+ * A `Maybe` can help you with optional arguments,
+ * error handling, and records with optional fields.
  */
 export interface Maybe<T> {
+    /**
+     * Conveniently check if a `Maybe` matches `Nothing`.
+     *
+     * @example
+     * Just(42).isNothing() == false
+     *
+     * Just([]).isNothing() == false
+     *
+     * Nothing.isNothing() == true
+     */
     isNothing(): boolean;
+
+    /**
+     * Conveniently check if a `Maybe` matches `Just<any>`.
+     *
+     * @example
+     * Just(42).isJust() == true
+     *
+     * Just([]).isJust() == true
+     *
+     * Nothing.isJust() == false
+     */
     isJust(): boolean;
+
+    /**
+     * Check if the `Maybe` equals to another `Maybe`.
+     *
+     * @param another `Maybe` to check equality.
+     */
     isEqual<D>(another: Maybe<WhenNever<T, D>>): boolean;
 
+    /**
+     * Transform the `Maybe` value with a given function.
+     *
+     * @param fn transforming function.
+     */
     map<R>(fn: (value: T) => R): Maybe<R>;
+
+    /**
+     * Chain together many computations that may fail.
+     *
+     * @param fn chaining function.
+     */
     chain<R>(fn: (value: T) => Maybe<R>): Maybe<R>;
     filter(fn: (value: T) => boolean): Maybe<T>;
     ap<R>(maybeFn: Maybe<(value: T) => R>): Maybe<R>;

--- a/src/RemoteData.ts
+++ b/src/RemoteData.ts
@@ -2,11 +2,7 @@ import {
     WhenNever,
     Cata
 } from './Basics';
-import {
-    Maybe,
-    Nothing,
-    Just
-} from './Maybe';
+import Maybe, { Nothing, Just } from './Maybe';
 import {
     Either
 } from './Either';

--- a/src/Url/Parser.ts
+++ b/src/Url/Parser.ts
@@ -1,11 +1,7 @@
 import {
     Url
 } from './index';
-import {
-    Maybe,
-    Nothing,
-    Just
-} from '../Maybe';
+import Maybe, { Nothing, Just } from '../Maybe';
 
 interface Queries {
     readonly [ key: string ]: Array<string>;

--- a/src/Url/Parser.ts
+++ b/src/Url/Parser.ts
@@ -425,7 +425,7 @@ class QueryListImpl<A, B> implements QueryList<A, B> {
 
     public get number(): Parser<FF<A, (values: Array<number>) => B>, B> {
         return this.custom(values => {
-            return Maybe.sequence(values.map(parseInt)).getOrElse([]);
+            return Maybe.list(values.map(parseInt)).getOrElse([]);
         });
     }
 
@@ -440,7 +440,7 @@ class QueryListImpl<A, B> implements QueryList<A, B> {
         const dict = buildDict(variants);
 
         return this.custom(values => {
-            return Maybe.sequence(
+            return Maybe.list(
                 values.map(key => Maybe.fromNullable(dict[ key ]))
             ).getOrElse([]);
         });

--- a/src/Url/Parser.ts
+++ b/src/Url/Parser.ts
@@ -421,7 +421,7 @@ class QueryListImpl<A, B> implements QueryList<A, B> {
 
     public get number(): Parser<FF<A, (values: Array<number>) => B>, B> {
         return this.custom(values => {
-            return Maybe.list(values.map(parseInt)).getOrElse([]);
+            return Maybe.combine(values.map(parseInt)).getOrElse([]);
         });
     }
 
@@ -436,7 +436,7 @@ class QueryListImpl<A, B> implements QueryList<A, B> {
         const dict = buildDict(variants);
 
         return this.custom(values => {
-            return Maybe.list(
+            return Maybe.combine(
                 values.map(key => Maybe.fromNullable(dict[ key ]))
             ).getOrElse([]);
         });

--- a/src/Url/index.ts
+++ b/src/Url/index.ts
@@ -1,11 +1,7 @@
 import {
     Cata
 } from '../Basics';
-import {
-    Maybe,
-    Nothing,
-    Just
-} from '../Maybe';
+import Maybe, { Nothing, Just } from '../Maybe';
 import {
     Parser
 } from './Parser';

--- a/test/Maybe.test.ts
+++ b/test/Maybe.test.ts
@@ -280,6 +280,25 @@ test('Maybe.prototype.chain()', t => {
     );
 });
 
+test('Maybe.prototype.filter()', t => {
+    const isEven = (a: number) => a % 2 === 0;
+
+    t.deepEqual(
+        Nothing.filter(isEven),
+        Nothing
+    );
+
+    t.deepEqual(
+        Just(1).filter(isEven),
+        Nothing
+    );
+
+    t.deepEqual(
+        Just(2).filter(isEven),
+        Just(2)
+    );
+});
+
 test('Maybe.prototype.ap()', t => {
     t.deepEqual(
         Nothing.ap(Nothing),

--- a/test/Maybe.test.ts
+++ b/test/Maybe.test.ts
@@ -1,10 +1,6 @@
 import test from 'ava';
 
-import {
-    Maybe,
-    Nothing,
-    Just
-} from '../src/Maybe';
+import Maybe, { Nothing, Just } from '../src/Maybe';
 import {
     Left,
     Right
@@ -167,41 +163,41 @@ test('Maybe.props()', t => {
     );
 });
 
-test('Maybe.sequence()', t => {
+test('Maybe.list()', t => {
     t.deepEqual(
-        Maybe.sequence([]),
+        Maybe.list([]),
         Just([])
     );
 
     t.deepEqual(
-        Maybe.sequence([ Nothing ]),
+        Maybe.list([ Nothing ]),
         Nothing
     );
 
     t.deepEqual(
-        Maybe.sequence([ Just(1) ]),
+        Maybe.list([ Just(1) ]),
         Just([ 1 ])
     );
 
     t.deepEqual(
-        Maybe.sequence([ Nothing, Nothing ]),
+        Maybe.list([ Nothing, Nothing ]),
         Nothing
     );
 
     t.deepEqual(
-        Maybe.sequence([ Nothing, Just(2) ]),
+        Maybe.list([ Nothing, Just(2) ]),
         Nothing
     );
 
     t.deepEqual(
-        Maybe.sequence([ Just(1), Nothing ]),
+        Maybe.list([ Just(1), Nothing ]),
         Nothing
     );
 
     const array = [ Just(1), Just(2) ];
 
     t.deepEqual(
-        Maybe.sequence(array),
+        Maybe.list(array),
         Just([ 1, 2 ])
     );
 

--- a/test/Maybe.test.ts
+++ b/test/Maybe.test.ts
@@ -616,6 +616,11 @@ test('Maybe.prototype.touch()', t => {
     );
 
     t.deepEqual(
+        Nothing.touch(Maybe.join),
+        Nothing
+    );
+
+    t.deepEqual(
         Just(1).touch(Just).touch(Maybe.join),
         Just(1)
     );

--- a/test/Maybe.test.ts
+++ b/test/Maybe.test.ts
@@ -163,41 +163,41 @@ test('Maybe.props()', t => {
     );
 });
 
-test('Maybe.list()', t => {
+test('Maybe.combine()', t => {
     t.deepEqual(
-        Maybe.list([]),
+        Maybe.combine([]),
         Just([])
     );
 
     t.deepEqual(
-        Maybe.list([ Nothing ]),
+        Maybe.combine([ Nothing ]),
         Nothing
     );
 
     t.deepEqual(
-        Maybe.list([ Just(1) ]),
+        Maybe.combine([ Just(1) ]),
         Just([ 1 ])
     );
 
     t.deepEqual(
-        Maybe.list([ Nothing, Nothing ]),
+        Maybe.combine([ Nothing, Nothing ]),
         Nothing
     );
 
     t.deepEqual(
-        Maybe.list([ Nothing, Just(2) ]),
+        Maybe.combine([ Nothing, Just(2) ]),
         Nothing
     );
 
     t.deepEqual(
-        Maybe.list([ Just(1), Nothing ]),
+        Maybe.combine([ Just(1), Nothing ]),
         Nothing
     );
 
     const array = [ Just(1), Just(2) ];
 
     t.deepEqual(
-        Maybe.list(array),
+        Maybe.combine(array),
         Just([ 1, 2 ])
     );
 

--- a/test/Maybe.test.ts
+++ b/test/Maybe.test.ts
@@ -208,6 +208,51 @@ test('Maybe.combine()', t => {
     );
 });
 
+test('Maybe.values()', t => {
+    t.deepEqual(
+        Maybe.values([]),
+        []
+    );
+
+    t.deepEqual(
+        Maybe.values([ Nothing ]),
+        []
+    );
+
+    t.deepEqual(
+        Maybe.values([ Just(1) ]),
+        [ 1 ]
+    );
+
+    t.deepEqual(
+        Maybe.values([ Nothing, Nothing ]),
+        []
+    );
+
+    t.deepEqual(
+        Maybe.values([ Nothing, Just(2) ]),
+        [ 2 ]
+    );
+
+    t.deepEqual(
+        Maybe.values([ Just(1), Nothing ]),
+        [ 1 ]
+    );
+
+    const array = [ Just(1), Just(2) ];
+
+    t.deepEqual(
+        Maybe.values(array),
+        [ 1, 2 ]
+    );
+
+    t.deepEqual(
+        array,
+        [ Just(1), Just(2) ],
+        'checking of Array immutability'
+    );
+});
+
 test('Maybe.prototype.isNothing()', t => {
     t.true(Nothing.isNothing());
 

--- a/test/Maybe.test.ts
+++ b/test/Maybe.test.ts
@@ -559,6 +559,46 @@ test('Maybe.prototype.cata()', t => {
     );
 });
 
+test('Maybe.prototype.touch()', t => {
+    const someFuncHandeMaybe = (maybeNumber: Maybe<number>): string => {
+        return maybeNumber.map(num => num * 2 + '_').getOrElse('_');
+    };
+
+    t.is(
+        Nothing
+            .orElse(() => Just(20))
+            .map(a => a * a)
+            .touch(someFuncHandeMaybe)
+            .replace('_', '|')
+            .trim(),
+
+        someFuncHandeMaybe(
+            Nothing
+                .orElse(() => Just(20))
+                .map(a => a * a)
+        )
+        .replace('_', '|')
+        .trim()
+    );
+
+    t.is(
+        Just(1)
+            .map(a => a - 1)
+            .chain(a => a > 0 ? Just(a) : Nothing)
+            .touch(someFuncHandeMaybe)
+            .repeat(10)
+            .trim(),
+
+        someFuncHandeMaybe(
+            Just(1)
+            .map(a => a - 1)
+            .chain(a => a > 0 ? Just(a) : Nothing)
+        )
+        .repeat(10)
+        .trim()
+    );
+});
+
 test('Maybe.prototype.toEither()', t => {
     t.deepEqual(
         Nothing.toEither('err'),

--- a/test/Maybe.test.ts
+++ b/test/Maybe.test.ts
@@ -36,6 +36,23 @@ test('Maybe.fromEither()', t => {
     );
 });
 
+test('Maybe.join()', t => {
+    t.deepEqual(
+        Maybe.join(Nothing),
+        Nothing
+    );
+
+    t.deepEqual(
+        Maybe.join(Just(Nothing)),
+        Nothing
+    );
+
+    t.deepEqual(
+        Maybe.join(Just(Just(1))),
+        Just(1)
+    );
+});
+
 test('Maybe.props()', t => {
     t.deepEqual(
         Maybe.props({}),
@@ -596,6 +613,11 @@ test('Maybe.prototype.touch()', t => {
         )
         .repeat(10)
         .trim()
+    );
+
+    t.deepEqual(
+        Just(1).touch(Just).touch(Maybe.join),
+        Just(1)
     );
 });
 

--- a/test/Url/Parser.test.ts
+++ b/test/Url/Parser.test.ts
@@ -23,7 +23,7 @@ const parseDate = (str: string): Maybe<Date> => {
 const parseDateQuery = (value: Maybe<string>): Maybe<Date> => value.chain(parseDate);
 
 const parseDateQueries = (values: Array<string>): Array<Date> => {
-    return Maybe.sequence(values.map(parseDate)).getOrElse([]);
+    return Maybe.list(values.map(parseDate)).getOrElse([]);
 };
 
 const serializeDate = (date: Date): string => {

--- a/test/Url/Parser.test.ts
+++ b/test/Url/Parser.test.ts
@@ -23,7 +23,7 @@ const parseDate = (str: string): Maybe<Date> => {
 const parseDateQuery = (value: Maybe<string>): Maybe<Date> => value.chain(parseDate);
 
 const parseDateQueries = (values: Array<string>): Array<Date> => {
-    return Maybe.list(values.map(parseDate)).getOrElse([]);
+    return Maybe.combine(values.map(parseDate)).getOrElse([]);
 };
 
 const serializeDate = (date: Date): string => {

--- a/tslint.json
+++ b/tslint.json
@@ -38,7 +38,7 @@
     "deprecation": true,
     "indent": [ true, "spaces", 4 ],
     "max-classes-per-file": false,
-    "no-default-export": true,
+    "no-default-export": false,
     "no-duplicate-imports": true,
     "no-require-imports": true,
     "object-literal-sort-keys": false,


### PR DESCRIPTION
Updates: 
- `Basics.Cata` simplified.
- `Maybe.list` → `Maybe.combine`
- \+ `Maybe.join`
- \+ `Maybe.values`
- \+ `Maybe.prototype.touch`
- \+ `Maybe.prototype.filter`
- `Maybe` jsdocs added
- Iterating of `Maybe.combine` and `Maybe.props` optimised.