### PR TITLE
Refactoring either

### DIFF
--- a/src/Basics.ts
+++ b/src/Basics.ts
@@ -12,6 +12,8 @@ export type IsNever<A, T, F> = [ A ] extends [ never ] ? T : F;
 
 export type WhenNever<A, T> = [ A, T ] extends [ T, A ] ? A : IsNever<A, T, A>;
 
+export type Default<T> = WhenNever<T, unknown>;
+
 export type Cata<O extends {[ K in keyof O ]: (...args: Array<unknown>) => unknown } & { _?: never }>
     = O extends {[ K in keyof O ]: (...args: Array<unknown>) => infer R }
     ? Compute<O & { _?(): never }> | Compute<Optional<O> & { _(): R }>

--- a/src/Basics.ts
+++ b/src/Basics.ts
@@ -12,13 +12,13 @@ export type IsNever<A, T, F> = [ A ] extends [ never ] ? T : F;
 
 export type WhenNever<A, T> = [ A, T ] extends [ T, A ] ? A : IsNever<A, T, A>;
 
-export type Default<T> = WhenNever<T, unknown>;
-
 export type Cata<O extends {[ K in keyof O ]: (...args: Array<unknown>) => unknown } & { _?: never }>
     = O extends {[ K in keyof O ]: (...args: Array<unknown>) => infer R }
     ? Compute<O & { _?(): never }> | Compute<Optional<O> & { _(): R }>
     : never
     ;
+
+export const identity = <T>(value: T): T => value;
 
 export const inst = <T>(Constructor: new () => T) => new Constructor();
 

--- a/src/Either.ts
+++ b/src/Either.ts
@@ -3,8 +3,8 @@ import {
     Return,
     IsNever,
     WhenNever,
-    Default,
-    Cata
+    Cata,
+    identity
 } from './Basics';
 import Maybe, { Nothing, Just } from './Maybe';
 
@@ -19,48 +19,139 @@ export namespace Either {
 
 export type Pattern<E, T, R> = Either.Pattern<E, T, R>;
 
-export interface Either<E, T> {
-    isLeft(): boolean;
-    isRight(): boolean;
-    isEqual<E_ extends Default<E>, T_ extends Default<T>>(another: Either<E_, T_>): boolean;
+export abstract class Either<E, T> {
+    public static Left<E>(error: E): Either<E, never> {
+        return new Variants.Left(error);
+    }
 
-    map<R>(fn: (value: T) => R): Either<E, R>;
-    mapLeft<S>(fn: (error: E) => S): Either<S, T>;
-    mapBoth<S, R>(leftFn: (error: E) => S, rightFn: (value: T) => R): Either<S, R>;
-    chain<E_ extends Default<E>, R>(fn: (value: T) => Either<E_, R>): Either<E_, R>;
-    ap<E_ extends Default<E>, F extends (value: T) => unknown>(
-        eitherFn: Either<E_, F>
-    ): Either<E_, WhenNever<Return<F>, T>>;
-    pipe<E_>(either: Wrap<WhenNever<E, E_>, Arg<T>>): Either<WhenNever<E, E_>, Return<T>>;
-    swap(): Either<T, E>;
-    orElse<E_, T_>(
-        fn: () => Either<WhenNever<E, E_>, WhenNever<T, T_>>
+    public static Right<T>(value: T): Either<never, T> {
+        return new Variants.Right(value);
+    }
+
+    public static fromNullable<E, T>(
+        error: E, value: T | null | undefined
+    ): Either<E, T extends null | undefined ? never : T> {
+        return value == null
+            ? Left(error)
+            : Right(value as T extends null | undefined ? never : T);
+    }
+
+    public static fromMaybe<E, T>(error: E, maybe: Maybe<T>): Either<E, T> {
+        return maybe.fold((): Either<E, T> => Left(error), Right);
+    }
+
+    public static merge<T>(either: Either<T, T>): T {
+        return either.fold(identity, identity);
+    }
+
+    public static props<E, O extends object>(config: {[ K in keyof O ]: Either<E, O[ K ]>}): Either<E, O> {
+        const acc: O = {} as O;
+
+        for (const key in config) {
+            if (config.hasOwnProperty(key)) {
+                const value = config[ key ];
+
+                if (value.isLeft()) {
+                    return value as Either<E, never>;
+                }
+
+                acc[ key ] = value.getOrElse(null as never /* don't use this hack */);
+            }
+        }
+
+        return Right(acc);
+    }
+
+    public static combine<E, T>(array: Array<Either<E, T>>): Either<E, Array<T>> {
+        const acc: Array<T> = [];
+
+        for (const item of array) {
+            if (item.isLeft()) {
+                return item as Either<E, never>;
+            }
+
+            acc.push(item.getOrElse(null as never /* don't use this hack */));
+        }
+
+        return Right(acc);
+    }
+
+    public isLeft(): boolean {
+        return false;
+    }
+
+    public isRight(): boolean {
+        return false;
+    }
+
+    public abstract isEqual<E_, T_>(another: Either<WhenNever<E, E_>, WhenNever<T, T_>>): boolean;
+
+    public abstract map<R>(fn: (value: T) => R): Either<E, R>;
+
+    public abstract mapLeft<S>(fn: (error: E) => S): Either<S, T>;
+
+    public abstract chain<E_, R>(fn: (value: T) => Either<WhenNever<E, E_>, R>): Either<WhenNever<E, E_>, R>;
+
+    public abstract ap<E_, R = never>(
+        eitherFn: Either<WhenNever<E, E_>, (value: T) => R>
+    ): Either<WhenNever<E, E_>, WhenNever<R, T>>;
+
+    public abstract pipe<E_>(either: Wrap<WhenNever<E, E_>, Arg<T>>): Either<WhenNever<E, E_>, Return<T>>;
+
+    public abstract orElse<E_, T_>(
+        fn: (error: WhenNever<E, E_>) => Either<WhenNever<E, E_>, WhenNever<T, T_>>
     ): Either<WhenNever<E, E_>, WhenNever<T, T_>>;
 
-    getOrElse<T_ extends Default<T>>(defaults: T_): T_;
-    // extract(fn: (error: E) => T): T;
-    fold<R>(leftFn: (error: E) => R, rightFn: (value: T) => R): R;
-    cata<R>(pattern: Pattern<E, T, R>): R;
-    // touch<R>(fn: (that: Eith<E, T>) => R): R;
+    public abstract getOrElse<T_>(defaults: WhenNever<T, T_>): WhenNever<T, T_>;
 
-    toMaybe(): Maybe<T>;
+    public mapBoth<S, R>(leftFn: (error: E) => S, rightFn: (value: T) => R): Either<S, R> {
+        return this.map(rightFn).mapLeft(leftFn);
+    }
+
+    public swap(): Either<T, E> {
+        return this.fold(
+            Right as (value: E) => Either<T, E>,
+            Left as (error: T) => Either<T, E>
+        );
+    }
+
+    public extract(fn: (error: E) => T): T {
+        return this.fold(fn, identity);
+    }
+
+    public fold<R>(leftFn: (error: E) => R, rightFn: (value: T) => R): R {
+        return this.cata({
+            Left: leftFn,
+            Right: rightFn
+        });
+    }
+
+    public cata<R>(pattern: Pattern<E, T, R>): R {
+        return (pattern._ as () => R)();
+    }
+
+    public touch<R>(fn: (that: Either<E, T>) => R): R {
+        return fn(this);
+    }
+
+    public toMaybe(): Maybe<T> {
+        return this.fold(() => Nothing, Just);
+    }
 }
 
 namespace Variants {
-    export class Left<E> implements Either<E, never> {
-        public constructor(private readonly error: E) {}
+    export class Left<E> extends Either<E, never> {
+        public constructor(private readonly error: E) {
+            super();
+        }
 
         public isLeft(): boolean {
             return true;
         }
 
-        public isRight(): boolean {
-            return false;
-        }
-
-        public isEqual<E_ extends Default<E>>(another: Either<E_, never>): boolean {
+        public isEqual<E_>(another: Either<WhenNever<E, E_>, never>): boolean {
             return another.fold(
-                (error: E_): boolean => this.error === error,
+                (error: WhenNever<E, E_>): boolean => this.error === error,
                 (): boolean => false
             );
         }
@@ -73,36 +164,26 @@ namespace Variants {
             return new Left(fn(this.error));
         }
 
-        public mapBoth<S>(leftFn: (error: E) => S): Either<S, never> {
-            return this.mapLeft(leftFn);
+        public chain<E_>(): Either<WhenNever<E, E_>, never> {
+            return this as unknown as Either<WhenNever<E, E_>, never>;
         }
 
-        public chain<E_ extends Default<E>>(): Either<E_, never> {
-            return this as unknown as Either<E_, never>;
-        }
-
-        public ap<E_ extends Default<E>>(): Either<E_, never> {
-            return this as unknown as Either<E_, never>;
+        public ap<E_>(): Either<WhenNever<E, E_>, never> {
+            return this as unknown as Either<WhenNever<E, E_>, never>;
         }
 
         public pipe<E_>(): Either<WhenNever<E, E_>, never> {
             return this as unknown as Either<WhenNever<E, E_>, never>;
         }
 
-        public swap(): Either<never, E> {
-            return new Right(this.error);
-        }
-
-        public orElse<E_>(fn: () => Either<WhenNever<E, E_>, never>): Either<WhenNever<E, E_>, never> {
-            return fn();
+        public orElse<E_>(
+            fn: (error: WhenNever<E, E_>) => Either<WhenNever<E, E_>, never>
+        ): Either<WhenNever<E, E_>, never> {
+            return fn(this.error as WhenNever<E, E_>);
         }
 
         public getOrElse<T>(defaults: T): T {
             return defaults;
-        }
-
-        public fold<R>(leftFn: (error: E) => R): R {
-            return leftFn(this.error);
         }
 
         public cata<R>(pattern: Pattern<E, never, R>): R {
@@ -110,29 +191,23 @@ namespace Variants {
                 return pattern.Left(this.error);
             }
 
-            return (pattern._ as () => R)();
-        }
-
-        public toMaybe(): Maybe<never> {
-            return Nothing;
+            return super.cata(pattern);
         }
     }
 
-    export class Right<T> implements Either<never, T> {
-        public constructor(private readonly value: T) {}
-
-        public isLeft(): boolean {
-            return false;
+    export class Right<T> extends Either<never, T> {
+        public constructor(private readonly value: T) {
+            super();
         }
 
         public isRight(): boolean {
             return true;
         }
 
-        public isEqual<T_ extends Default<T>>(another: Either<never, T_>): boolean {
+        public isEqual<T_>(another: Either<never, WhenNever<T, T_>>): boolean {
             return another.fold(
                 (): boolean => false,
-                (value: T_): boolean => this.value === value
+                (value: WhenNever<T, T_>): boolean => this.value === value
             );
         }
 
@@ -144,38 +219,28 @@ namespace Variants {
             return this;
         }
 
-        public mapBoth<R>(_leftFn: (error: never) => never, rightFn: (value: T) => R): Either<never, R> {
-            return this.map(rightFn);
-        }
-
         public chain<R>(fn: (value: T) => Either<never, R>): Either<never, R> {
             return fn(this.value);
-        }
-
-        public ap<F extends (value: T) => unknown>(eitherFn: Either<never, F>): Either<never, WhenNever<Return<F>, T>> {
-            return eitherFn.pipe(
-                this as unknown as IsNever<Arg<F>, never, Either<never, Arg<F>>>
-            ) as unknown as Either<never, WhenNever<Return<F>, T>>;
         }
 
         public pipe(either: Wrap<never, Arg<T>>): Either<never, Return<T>> {
             return either.map(this.value as unknown as (value: Arg<T>) => Return<T>);
         }
 
-        public swap(): Either<T, never> {
-            return new Left(this.value);
+        public ap<R>(
+            eitherFn: Either<never, (value: T) => R>
+        ): Either<never, WhenNever<R, T>> {
+            return eitherFn.pipe(
+                this as unknown as IsNever<T, never, Either<never, T>>
+            ) as Either<never, WhenNever<R, T>>;
         }
 
         public orElse<T_>(): Either<never, WhenNever<T, T_>> {
             return this as unknown as Either<never, WhenNever<T, T_>>;
         }
 
-        public getOrElse<T_ extends Default<T>>(): T_ {
-            return this.value as T_;
-        }
-
-        public fold<R>(_leftFn: (error: never) => R, rightFn: (value: T) => R): R {
-            return rightFn(this.value);
+        public getOrElse<T_>(): WhenNever<T, T_> {
+            return this.value as WhenNever<T, T_>;
         }
 
         public cata<R>(pattern: Pattern<never, T, R>): R {
@@ -183,85 +248,23 @@ namespace Variants {
                 return pattern.Right(this.value);
             }
 
-            return (pattern._ as () => R)();
-        }
-
-        public toMaybe(): Maybe<T> {
-            return Just(this.value);
+            return super.cata(pattern);
         }
     }
 }
 
-export const Left = <E>(error: E): Either<E, never> => new Variants.Left(error);
+export const Left = Either.Left;
 
-export const Right = <T>(value: T): Either<never, T> => new Variants.Right(value);
+export const Right = Either.Right;
 
-export const fromNullable = <E, T>(
-    error: E, value: T | null | undefined
-): Either<E, T extends null | undefined ? never : T> => {
-    return value == null
-        ? Left(error)
-        : Right(value as T extends null | undefined ? never : T);
-};
+export const fromNullable = Either.fromNullable;
 
-export const fromMaybe = <E, T>(error: E, maybe: Maybe<T>): Either<E, T> => {
-    return maybe.fold((): Either<E, T> => Left(error), Right);
-};
+export const fromMaybe = Either.fromMaybe;
 
-// export const merge = () => {}
+export const merge = Either.merge;
 
-export const props = <E, O extends object>(config: {[ K in keyof O ]: Either<E, O[ K ]>}): Either<E, O> => {
-    const acc: O = {} as O;
+export const props = Either.props;
 
-    for (const key in config) {
-        if (config.hasOwnProperty(key)) {
-            const value = config[ key ];
+export const combine = Either.combine;
 
-            if (value.isLeft()) {
-                return value as Either<E, never>;
-            }
-
-            acc[ key ] = value.getOrElse(null as never /* don't use this hack */);
-        }
-    }
-
-    return Right(acc);
-};
-
-export const combine = <E, T>(array: Array<Either<E, T>>): Either<E, Array<T>> => {
-    const acc: Array<T> = [];
-
-    for (const item of array) {
-        if (item.isLeft()) {
-            return item as Either<E, never>;
-        }
-
-        acc.push(item.getOrElse(null as never /* don't use this hack */));
-    }
-
-    return Right(acc);
-};
-
-// export const test$isEqual$1 = Lef('').isEqual(Lef(''));
-// export const test$isEqual$2 = Lef('').isEqual(Rig(1));
-// export const test$isEqual$3 = Rig(1).isEqual(Lef(''));
-// export const test$isEqual$4 = Rig(1).isEqual(Rig(1));
-
-// export const test$chain$1 = Lef('').chain((a: boolean) => a ? Lef('') : Rig(1));
-// export const test$chain$2 = Rig(true).chain((a: boolean) => a ? Lef('') : Rig(1));
-
-// export const test$ap$1 = Lef('').ap(Lef(''));
-// export const test$ap$2 = Lef('').ap(Rig((a: number) => a > 0));
-// export const test$ap$3 = Rig(1).ap(Lef(''));
-// export const test$ap$4 = Rig(1).ap(Rig((a: number) => a > 0));
-
-// export const test$orElse1 = Lef('').orElse(() => Lef(''));
-// export const test$orElse2 = Lef('').orElse(() => Rig(1));
-// export const test$orElse3 = Rig(1).orElse(() => Lef(''));
-// export const test$orElse4 = Rig(1).orElse(() => Rig(1));
-
-// export const test$pipe$1 = Rig((a: number) => (b: string) => (c: boolean) => c ? b : a * 2 + '')
-//     .pipe(Lef(1))
-//     .pipe(Rig(''))
-//     .pipe(Lef(1))
-//     ;
+export default Either;

--- a/src/Either.ts
+++ b/src/Either.ts
@@ -96,9 +96,6 @@ export abstract class Either<E, T> {
 
     public abstract mapLeft<S>(fn: (error: E) => S): Either<S, T>;
 
-    /**
-     * @todo fix _2 case
-     */
     public abstract chain<E_, R>(
         fn: (value: T) => Either<WhenNever<E, E_>, R>
     ): Either<WhenNever<E, E_>, R>;

--- a/src/Either.ts
+++ b/src/Either.ts
@@ -305,8 +305,8 @@ export abstract class Either<E, T> {
      * Left('error').extract((e: string) => e.length) // 5
      * Right(0).extract((e: string) => e.length)      // 0
      */
-    public extract(fn: (error: E) => T): T {
-        return this.fold(fn, identity);
+    public extract<T_>(fn: (error: E) => WhenNever<T, T_>): WhenNever<T, T_> {
+        return this.fold(fn, identity as (value: T) => WhenNever<T, T_>);
     }
 
     /**

--- a/src/Either.ts
+++ b/src/Either.ts
@@ -85,7 +85,7 @@ export abstract class Either<E, T> {
      * merge(Left('error'))                                    // 'error'
      * merge(Right('value'))                                   // 'value'
      * merge(Left('error').orElse(() => Right('value')))       // 'value'
-     * Left('error').chain(() => Right('value')).touch(merge)  // 'error'
+     * Left('error').chain(() => Right('value')).pipe(merge)   // 'error'
      */
     public static merge<T>(either: Either<T, T>): T {
         return either.fold(identity, identity);
@@ -362,7 +362,7 @@ export abstract class Either<E, T> {
      *
      * Right(42)
      *     .chain((a: number) => a > 0 ? Right(42 / 2) : Left('The number is negative'))
-     *     .touch(helperFunction)
+     *     .pipe(helperFunction)
      *     .toFixed(2)
      *
      * // equals to
@@ -371,7 +371,7 @@ export abstract class Either<E, T> {
      *     Right(42).chain((a: number) => a > 0 ? Right(42 / 2) : Left('The number is negative'))
      * ).toFixed(2)
      */
-    public touch<R>(fn: (that: Either<E, T>) => R): R {
+    public pipe<R>(fn: (that: Either<E, T>) => R): R {
         return fn(this);
     }
 

--- a/src/Either.ts
+++ b/src/Either.ts
@@ -11,40 +11,108 @@ import Maybe, { Nothing, Just } from './Maybe';
 type Wrap<E, T> = IsNever<T, never, Either<E, T>>;
 
 export namespace Either {
+    /**
+     * Pattern for matching the `Either` variants.
+     */
     export type Pattern<E, T, R> = Cata<{
         Left(error: E): R;
         Right(value: T): R;
     }>;
 }
 
-export type Pattern<E, T, R> = Either.Pattern<E, T, R>;
-
+/**
+ * A data structure that models the result of operations that may fail.
+ * A `Either` helps with representing errors and propagating them,
+ * giving users a more controllable form of sequencing operations
+ * than that offered by constructs like `try/catch`.
+ */
 export abstract class Either<E, T> {
+    /**
+     * Represents a `Either` containing the failure `error`.
+     *
+     * @param error
+     */
     public static Left<E>(error: E): Either<E, never> {
         return new Variants.Left(error);
     }
 
+    /**
+     * Represents a `Either` containing the successful `value`.
+     *
+     * @param value
+     */
     public static Right<T>(value: T): Either<never, T> {
         return new Variants.Right(value);
     }
 
+    /**
+     * Converts nullable `value` into `Either`.
+     * `null` and `undefined` become `Left(error)` otherwise `Right(value)`
+     *
+     * @param error Failure error.
+     * @param value Nullable value.
+     *
+     * @example
+     * fromNullable('Error', null)                          // Left('Error')
+     * fromNullable('undefined', JSON.stringify(undefined)) // Left('undefined')
+     * fromNullable('undefined', JSON.stringify('valid'))   // Right('"valid"')
+     */
     public static fromNullable<E, T>(
-        error: E, value: T | null | undefined
+        error: E,
+        value: T | null | undefined
     ): Either<E, T extends null | undefined ? never : T> {
         return value == null
             ? Left(error)
             : Right(value as T extends null | undefined ? never : T);
     }
 
+    /**
+     * Converts `Maybe` to `Either`.
+     * `Nothing` becomes `Left(error)`, `Just(value)` becomes `Right(value)`.
+     *
+     * @param error  Failure error.
+     * @param either Converted `Either`.
+     *
+     * @example
+     * fromEither('error', Nothing) // Left('error')
+     * fromEither(Just(42))         // Right(42)
+     */
     public static fromMaybe<E, T>(error: E, maybe: Maybe<T>): Either<E, T> {
         return maybe.fold((): Either<E, T> => Left(error), Right);
     }
 
+    /**
+     * Eliminate `Either` when error and success have been mapped to the same type.
+     *
+     * @param either
+     *
+     * @example
+     * merge(Left('error'))                                    // 'error'
+     * merge(Right('value'))                                   // 'value'
+     * merge(Left('error').orElse(() => Right('value')))       // 'value'
+     * Left('error').chain(() => Right('value')).touch(merge)  // 'error'
+     */
     public static merge<T>(either: Either<T, T>): T {
         return either.fold(identity, identity);
     }
 
     /**
+     * Take an object of `Either`s and return a `Either` with an object of values.
+     * Returns `Left` if at least one of the fields is `Left`.
+     *
+     * @param config Object of `Either`s.
+     *
+     * @example
+     * props({
+     *     id: Right(0),
+     *     title: Left('error')
+     * }) // Left('error')
+     *
+     * props({
+     *     id: Right(0),
+     *     title: Right('name')
+     * }) // Right({ id: 0, title: 'name' })
+     *
      * @todo fix the `E` calculation. Now it's always `unknown`.
      */
     public static props<E, O extends {}>(config: {[ K in keyof O ]: Either<E, O[ K ]>}): Either<E, O> {
@@ -65,6 +133,16 @@ export abstract class Either<E, T> {
         return Right(acc);
     }
 
+    /**
+     * Take an array of `Either`s and return a `Either` with an array of values.
+     * Returns `Left` if at least one of the items is `Left`.
+     *
+     * @param array Array of `Either`s.
+     *
+     * @example
+     * combine([ Left('error'), Right(42) ]) // Left('error')
+     * combine([ Right(1), Right(2) ])       // Right([ 1, 2 ])
+     */
     public static combine<E, T>(array: Array<Either<E, T>>): Either<
         unknown extends E ? never : E,
         Array<unknown extends T ? never : T>
@@ -82,40 +160,160 @@ export abstract class Either<E, T> {
         return Right(acc as Array<unknown extends T ? never : T>);
     }
 
+    /**
+     * Conveniently check if a `Either` matches as `Left`.
+     *
+     * @example
+     * Left('error').isLeft() // true
+     * Right(42).isLeft()     // false
+     */
     public isLeft(): boolean {
         return false;
     }
 
+    /**
+     * Conveniently check if a `Either` matches as `Right`.
+     *
+     * @example
+     * Left('error').isRight() // false
+     * Right(42).isRight()     // true
+     */
     public isRight(): boolean {
         return false;
     }
 
+    /**
+     * Check if the `Either` equals to another `Either`.
+     *
+     * @param another `Either` to check equality.
+     *
+     * @example
+     * Left('error').isEqual(Left('error'))   // true
+     * Left('error').isEqual(Left('message')) // false
+     * Left('error').isEqual(Right(42))       // false
+     * Right(42).isEqual(Left('message'))     // false
+     * Right(42).isEqual(Right(13))           // false
+     * Right(42).isEqual(Right(42))           // true
+     */
     public abstract isEqual<E_, T_>(another: Either<WhenNever<E, E_>, WhenNever<T, T_>>): boolean;
 
+    /**
+     * Transform the `Either` value with a given function.
+     *
+     * @param fn Transforming function.
+     *
+     * @example
+     * Left('error').map((a: number) => a > 0) // Left('error')
+     * Right(3).map((a: number) => a > 0)    // Right(true)
+     */
     public abstract map<R>(fn: (value: T) => R): Either<E, R>;
 
+    /**
+     * Transform the `Either` error with a given function.
+     *
+     * @param fn Transforming function.
+     *
+     * @example
+     * Left('error').mapLeft((a: string) => a.length) // Left(5)
+     * Right(true).mapLeft((a: string) => a.length)   // Right(true)
+     */
     public abstract mapLeft<S>(fn: (error: E) => S): Either<S, T>;
 
+    /**
+     * Chain together many computations that may fail.
+     *
+     * @param fn Chaining function.
+     *
+     * @example
+     * Left('error').chain((a: number) => a > 0 ? Right(a < 2) : Left('negate'))  // Left('error')
+     * Just(3).chain((a: number) => a > 0 ? Right(a < 2) : Left('negate'))        // Right(false)
+     * Just(1).chain((a: number) => a > 0 ? Right(a < 2) : Left('negate'))        // Right(true)
+     * Just(-3).chain((a: number) => a > 0 ? Right(a < 2) : Left('negate'))       // Left('negate')
+     */
     public abstract chain<E_, R>(
         fn: (value: T) => Either<WhenNever<E, E_>, R>
     ): Either<WhenNever<E, E_>, R>;
 
+    /**
+     * Apply a `eitherFn` function to the `Either` value.
+     *
+     * @param eitherFn `Either` function.
+     *
+     * @example
+     * Left('1').ap(Left('2'))                   // Left('1')
+     * Left('1').ap(Right((a: number) => a > 0)) // Left('1')
+     * Right(1).ap(Left('1'))                    // Left('1')
+     * Right(1).ap(Right((a: number) => a > 0))  // Right(true)
+     */
     public abstract ap<E_, R = never>(
         eitherFn: Either<WhenNever<E, E_>, (value: T) => R>
     ): Either<WhenNever<E, E_>, WhenNever<R, T>>;
 
+    /**
+     * Apply a `either` value into the inner function.
+     *
+     * @param either `Either` value to apply.
+     *
+     * @example
+     * Right((a: number) => (b: boolean) => b ? 0 a * s)
+     *     .pipe(Right(42))
+     *     .pipe(Left('error'))
+     *     // Left('error')
+     *
+     * Right((a: number) => (b: boolean) => b ? 0 : a * 2)
+     *     .pipe(Right(3))
+     *     .pipe(Right(true))
+     *     // Right(6)
+     */
     public abstract pipe<E_>(either: Wrap<WhenNever<E, E_>, Arg<T>>): Either<WhenNever<E, E_>, Return<T>>;
 
+    /**
+     * Like the boolean `||` this will return the first value that is `Right`.
+     *
+     * @param fn The function to return next `Right`.
+     *
+     * @example
+     * Left('error').orElse(e => Left(e + '_'))      // Left('error_')
+     * Right(1).orElse((e: string) => Left(e + '_')) // Right(1)
+     * Left('error').orElse(() => Right(1))          // Right(1)
+     * Right(1).orElse(() => Right(2))               // Right(1)
+     */
     public abstract orElse<E_, T_>(
         fn: (error: WhenNever<E, E_>) => Either<WhenNever<E, E_>, WhenNever<T, T_>>
     ): Either<WhenNever<E, E_>, WhenNever<T, T_>>;
 
+    /**
+     * Provide a `default` value, turning an dangerous value into a normal value.
+     *
+     * @param defaults The default `T`.
+     *
+     * @example
+     * Left('error').getOrElse(42) // 42
+     * Right(13).getOrElse(42)     // 13
+     */
     public abstract getOrElse<T_>(defaults: WhenNever<T, T_>): WhenNever<T, T_>;
 
-    public mapBoth<S, R>(leftFn: (error: E) => S, rightFn: (value: T) => R): Either<S, R> {
-        return this.map(rightFn).mapLeft(leftFn);
+    /**
+     * Transform both the `Either` value and error with the given functions.
+     *
+     * @param onRight Error transforming function.
+     * @param onLeft  Value transforming function.
+     *
+     * @example
+     * Left('error').mapBoth((a: number) => a > 0, (a: string) => a.length) // Left(5)
+     * Right(3).mapBoth((a: number) => a > 0, (a: string) => a.length)      // Right(true)
+     */
+    public mapBoth<S, R>(onLeft: (error: E) => S, onRight: (value: T) => R): Either<S, R> {
+        return this.map(onRight).mapLeft(onLeft);
     }
 
+    /**
+     * Swaps value and error.
+     *
+     * @example
+     * Left('error').swap() // Right('error')
+     * Right(1).swap()      // Left(1)
+     */
     public swap(): Either<T, E> {
         return this.fold(
             Right as (value: E) => Either<T, E>,
@@ -123,27 +321,94 @@ export abstract class Either<E, T> {
         );
     }
 
+    /**
+     * Turn a `Either` to an `T`, by applying the conversion function specified to the `E`.
+     *
+     * @param fn Conversion function.
+     *
+     * @example
+     * Left('error').extract((e: string) => e.length) // 5
+     * Right(0).extract((e: string) => e.length)      // 0
+     */
     public extract(fn: (error: E) => T): T {
         return this.fold(fn, identity);
     }
 
-    public fold<R>(leftFn: (error: E) => R, rightFn: (value: T) => R): R {
+    /**
+     * Fold the current `Either` according variant.
+     *
+     * @param onLeft  The function calls on the `Left` case.
+     * @param onRight The function calls on the `Right` case.
+     *
+     * @example
+     * Left('error').fold((e: string) => e === 'err', (a: number) => a > 0) // false
+     * Right(3).fold((e: string) => e === 'err', (a: number) => a > 0)      // true
+     */
+    public fold<R>(onLeft: (error: E) => R, onRight: (value: T) => R): R {
         return this.cata({
-            Left: leftFn,
-            Right: rightFn
+            Left: onLeft,
+            Right: onRight
         });
     }
 
+    /**
+     * Match the current `Either` to provided pattern.
+     *
+     * @param pattern Pattern matching.
+     *
+     * @example
+     * Left('error').cata({
+     *     Left: (e: string) => e === 'err'
+     *     Right: (a: number) => a > 0
+     * }) // false
+     *
+     * Right(3).cata({
+     *     Left: (e: string) => e === 'err'
+     *     Right: (a: number) => a > 0
+     * }) // true
+     */
     public cata<R>(pattern: Pattern<E, T, R>): R {
         return (pattern._ as () => R)();
     }
 
+    /**
+     * Apply the current `Either` to the predicate function.
+     * Could be usefull to make code more "linear".
+     *
+     * @param fn Predicate function.
+     *
+     * @example
+     * const helperFunction = (validatedNumber: Either<string, number>): number => {
+     *     return validatedNumber
+     *         .chain((a: number) => a < 100 ? Right(a) : Left('The number is too big'))
+     *         .map((a: number) => a * a)
+     *         .getOrElse(100)
+     * };
+     *
+     * Right(42)
+     *     .chain((a: number) => a > 0 ? Right(42 / 2) : Left('The number is negative'))
+     *     .touch(helperFunction)
+     *     .toFixed(2)
+     *
+     * // equals to
+     *
+     * helperFunction(
+     *     Right(42).chain((a: number) => a > 0 ? Right(42 / 2) : Left('The number is negative'))
+     * ).toFixed(2)
+     */
     public touch<R>(fn: (that: Either<E, T>) => R): R {
         return fn(this);
     }
 
+    /**
+     * Convert to `Maybe`.
+     *
+     * @example
+     * Left('error').toMaybe() // Nothing
+     * Right(42).toMaybe()     // Just(42)
+     */
     public toMaybe(): Maybe<T> {
-        return this.fold(() => Nothing, Just);
+        return this.map(Just).getOrElse(Nothing);
     }
 }
 
@@ -261,18 +526,47 @@ namespace Variants {
     }
 }
 
+/**
+ * @alias `Either.Pattern`
+ */
+export type Pattern<E, T, R> = Either.Pattern<E, T, R>;
+
+/**
+ * @alias `Either.Left`
+ */
 export const Left = Either.Left;
 
+/**
+ * @alias `Either.Right`
+ */
 export const Right = Either.Right;
 
+/**
+ * @alias `Either.fromNullable`
+ */
 export const fromNullable = Either.fromNullable;
 
+/**
+ * @alias `Either.fromMaybe`
+ */
 export const fromMaybe = Either.fromMaybe;
 
+/**
+ * @alias `Either.mergeght`
+ */
 export const merge = Either.merge;
 
+/**
+ * @alias `Either.propsght`
+ */
 export const props = Either.props;
 
+/**
+ * @alias `Either.combinet`
+ */
 export const combine = Either.combine;
 
+/**
+ * @alias `Either`
+ */
 export default Either;

--- a/src/Either.ts
+++ b/src/Either.ts
@@ -525,7 +525,7 @@ export const merge = Either.merge;
 export const props = Either.props;
 
 /**
- * @alias `Either.combinet`
+ * @alias `Either.combine`
  */
 export const combine = Either.combine;
 

--- a/src/Json/Decode.ts
+++ b/src/Json/Decode.ts
@@ -314,7 +314,7 @@ class List<T> extends Streamable<Array<T>> {
         for (let index = 0; index < input.length; index++) {
             result = result.chain(
                 (acc: Array<T>): Either<Error, Array<T>> => {
-                    return this.decoder.decode(input[ index ]).bimap(
+                    return this.decoder.decode(input[ index ]).mapBoth(
                         (error: Error): Error => Error.Index(index, error),
                         (value: T): Array<T> => {
                             acc.push(value);
@@ -346,7 +346,7 @@ class KeyValue<T> extends Streamable<Array<[ string, T ]>> {
             if (input.hasOwnProperty(key)) {
                 result = result.chain(
                     (acc: Array<[ string, T ]>): Either<Error, Array<[ string, T ]>> => {
-                        return this.decoder.decode(input[ key ]).bimap(
+                        return this.decoder.decode(input[ key ]).mapBoth(
                             (error: Error): Error => Error.Field(key, error),
                             (value: T): Array<[ string, T ]> => {
                                 acc.push([ key, value ]);

--- a/src/Maybe.ts
+++ b/src/Maybe.ts
@@ -226,7 +226,7 @@ export interface Maybe<T> {
     toEither<E>(error: E): Either<E, T>;
 }
 
-namespace MaybeVariants {
+namespace Variants {
     export class Nohting implements Maybe<never> {
         public isNothing(): boolean {
             return true;
@@ -360,14 +360,14 @@ namespace MaybeVariants {
 /**
  * Represents a `Maybe` containing no value.
  */
-export const Nothing: Maybe<never> = new MaybeVariants.Nohting();
+export const Nothing: Maybe<never> = new Variants.Nohting();
 
 /**
  * Constructs a `Maybe` containing the `value`.
  *
  * @param value The `Maybe` value.
  */
-export const Just = <T>(value: T): Maybe<T> => new MaybeVariants.Just(value);
+export const Just = <T>(value: T): Maybe<T> => new Variants.Just(value);
 
 /**
  * Converts nullable `value` into `Maybe`.

--- a/src/Maybe.ts
+++ b/src/Maybe.ts
@@ -437,11 +437,13 @@ export const props = <O extends object>(config: {[ K in keyof O ]: Maybe<O[ K ]>
 
     for (const key in config) {
         if (config.hasOwnProperty(key)) {
-            if (config[ key ].isNothing()) {
-                return Nothing;
+            const value = config[ key ];
+
+            if (value.isNothing()) {
+                return value as Maybe<never>;
             }
 
-            acc[ key ] = config[ key ].getOrElse(null as never /* don't use this hack */);
+            acc[ key ] = value.getOrElse(null as never /* don't use this hack */);
         }
     }
 
@@ -463,7 +465,7 @@ export const combine = <T>(array: Array<Maybe<T>>): Maybe<Array<T>> => {
 
     for (const item of array) {
         if (item.isNothing()) {
-            return Nothing;
+            return item as Maybe<never>;
         }
 
         acc.push(item.getOrElse(null as never /* don't use this hack */));

--- a/src/Maybe.ts
+++ b/src/Maybe.ts
@@ -64,7 +64,7 @@ export interface Maybe<T> {
      * Just(42).isEqual(Just(13)) // false
      * Just(42).isEqual(Just(42)) // true
      */
-    isEqual<D>(another: Maybe<WhenNever<T, D>>): boolean;
+    isEqual<T_>(another: Maybe<WhenNever<T, T_>>): boolean;
 
     /**
      * Transform the `Maybe` value with a given function.
@@ -144,7 +144,7 @@ export interface Maybe<T> {
      * Just(13).orElse(() => Nothing)  // Just(13)
      * Just(13).orElse(() => Just(42)) // Just(13)
      */
-    orElse<D>(fn: () => Maybe<WhenNever<T, D>>): Maybe<WhenNever<T, D>>;
+    orElse<T_>(fn: () => Maybe<WhenNever<T, T_>>): Maybe<WhenNever<T, T_>>;
 
     /**
      * Provide a `default` value, turning an optional value into a normal value.
@@ -155,7 +155,7 @@ export interface Maybe<T> {
      * Nothing.getOrElse(42)  // 42
      * Just(13).getOrElse(42) // 13
      */
-    getOrElse<D>(defaults: WhenNever<T, D>): WhenNever<T, D>;
+    getOrElse<T_>(defaults: WhenNever<T, T_>): WhenNever<T, T_>;
 
     /**
      * Fold the current `Maybe` according variant.
@@ -300,10 +300,10 @@ namespace MaybeVariants {
             return true;
         }
 
-        public isEqual<D>(another: Maybe<WhenNever<T, D>>): boolean {
+        public isEqual<T_>(another: Maybe<WhenNever<T, T_>>): boolean {
             return another.fold(
                 (): boolean => false,
-                (value: WhenNever<T, D>): boolean => this.value === value
+                (value: WhenNever<T, T_>): boolean => this.value === value
             );
         }
 
@@ -327,12 +327,12 @@ namespace MaybeVariants {
             return maybe.map(this.value as unknown as (value: Arg<T>) => Return<T>);
         }
 
-        public orElse<D>(): Maybe<WhenNever<T, D>> {
-            return this as unknown as Maybe<WhenNever<T, D>>;
+        public orElse<T_>(): Maybe<WhenNever<T, T_>> {
+            return this as unknown as Maybe<WhenNever<T, T_>>;
         }
 
-        public getOrElse<D>(): WhenNever<T, D> {
-            return this.value as WhenNever<T, D>;
+        public getOrElse<T_>(): WhenNever<T, T_> {
+            return this.value as WhenNever<T, T_>;
         }
 
         public fold<R>(_onNothing: () => R, onJust: (value: T) => R): R {

--- a/test/Either.test.ts
+++ b/test/Either.test.ts
@@ -65,7 +65,7 @@ test('Either.props()', t => {
         bar: never;
     }> */ = Either.props({
         foo: Left('err1'),
-        bar: Left(1)
+        bar: Left('err2')
     });
     t.deepEqual(_4, Left('err1'));
 
@@ -234,7 +234,7 @@ test('Either.prototype.chain()', t => {
     const _1 /* Either<string, never> */ = Left('err1').chain(() => Left('err2'));
     t.deepEqual(_1, Left('err1'));
 
-    const _2 /* Either<string, number> */ = Right(1).chain(() => Left('err'));
+    const _2 /* Either<string, never> */ = Right(1).chain(() => Left('err'));
     t.deepEqual(_2, Left('err'));
 
     const _3 /* Either<string, boolean> */ = Left('err').chain(a => Right(a > 0));

--- a/test/Either.test.ts
+++ b/test/Either.test.ts
@@ -194,7 +194,7 @@ test('Either.merge()', t => {
     const _3 /* string */ = Either.merge(Left('err').orElse(() => Right('ok')));
     t.deepEqual(_3, 'ok');
 
-    const _4 /* string */ = Left('err').orElse(() => Right('ok')).touch(Either.merge);
+    const _4 /* string */ = Left('err').orElse(() => Right('ok')).pipe(Either.merge);
     t.deepEqual(_4, 'ok');
 });
 
@@ -349,6 +349,61 @@ test('Either.prototype.cata()', t => {
         Right: a => '_' + a * 2
     });
     t.is(_2, '_4');
+});
+
+test('Either.prototype.pipe()', t => {
+    const someFuncHandeEither = (eitherNumber: Either<string, number>): string => {
+        return eitherNumber.map(num => num * 2 + '_').getOrElse('_');
+    };
+
+    t.is(
+        Left('err')
+            .orElse(() => Right(20))
+            .map(a => a * a)
+            .pipe(someFuncHandeEither)
+            .replace('_', '|')
+            .trim(),
+
+        someFuncHandeEither(
+            Left('err')
+                .orElse(() => Right(20))
+                .map(a => a * a)
+        )
+        .replace('_', '|')
+        .trim()
+    );
+
+    t.is(
+        Right(1)
+            .map(a => a - 1)
+            .chain(a => a > 0 ? Right(a) : Left('err'))
+            .pipe(someFuncHandeEither)
+            .repeat(10)
+            .trim(),
+
+        someFuncHandeEither(
+            Right(1)
+            .map(a => a - 1)
+            .chain(a => a > 0 ? Right(a) : Left('err'))
+        )
+        .repeat(10)
+        .trim()
+    );
+
+    t.deepEqual(
+        Left('err').pipe(Either.merge),
+        'err'
+    );
+
+    t.deepEqual(
+        Right('ok').pipe(Either.merge),
+        'ok'
+    );
+
+    t.deepEqual(
+        Left('err').orElse(() => Right('ok')).pipe(Either.merge),
+        'ok'
+    );
 });
 
 test('Either.prototype.toMaybe()', t => {

--- a/test/Either.test.ts
+++ b/test/Either.test.ts
@@ -291,6 +291,14 @@ test('Either.prototype.swap()', t => {
     t.deepEqual(_3, Left(1));
 });
 
+test('Either.prototype.extract()', t => {
+    const _1 /* number */ = Left('err').extract(str => str.length);
+    t.deepEqual(_1, 3);
+
+    const _2 /* number */ = Right(4).extract((str: string) => str.length);
+    t.deepEqual(_2, 4);
+});
+
 test('Either.prototype.mapLeft()', t => {
     const _1 /* Either<boolean, never> */ = Left('err').mapLeft(err => err === 'err');
     t.deepEqual(_1, Left(true));

--- a/test/Either.test.ts
+++ b/test/Either.test.ts
@@ -258,60 +258,6 @@ test('Either.prototype.ap()', t => {
     t.deepEqual(_4, Right(true));
 });
 
-test('Either.prototype.pipe()', t => {
-    const fnLeft: Either<string, (a: number) => string> = Left('_err_');
-    const fnRight = Right((a: number) => a > 0);
-
-    const _1 /* Either<string, string> */ = fnLeft.pipe(Left('err1'));
-    t.deepEqual(_1, Left('_err_'));
-
-    const _2 /* Either<string, string> */ = fnLeft.pipe(Right(2));
-    t.deepEqual(_2, Left('_err_'));
-
-    const _3 /* Either<string, boolean> */ = fnRight.pipe(Left('err1'));
-    t.deepEqual(_3, Left('err1'));
-
-    const _4 /* Either<never, boolean> */ = fnRight.pipe(Right(2));
-    t.deepEqual(_4, Right(true));
-
-    const trippleFnLeft: Either<string, (a: number) => (b: string) => (c: boolean) => string> = Left('_err_');
-    const trippleFnRight = Right((a: number) => (b: string) => (c: boolean) => c ? b : '_' + a * 2);
-
-    t.deepEqual(trippleFnLeft.pipe(Left('err1')).pipe(Left('err2')).pipe(Left('err3')), Left('_err_'));
-    t.deepEqual(trippleFnLeft.pipe(Left('err1')).pipe(Left('err2')).pipe(Right(true)),  Left('_err_'));
-    t.deepEqual(trippleFnLeft.pipe(Left('err1')).pipe(Right('hi')) .pipe(Left('err3')), Left('_err_'));
-    t.deepEqual(trippleFnLeft.pipe(Left('err1')).pipe(Right('hi')) .pipe(Right(true)),  Left('_err_'));
-    t.deepEqual(trippleFnLeft.pipe(Right(2))    .pipe(Left('err2')).pipe(Left('err3')), Left('_err_'));
-    t.deepEqual(trippleFnLeft.pipe(Right(2))    .pipe(Left('err2')).pipe(Right(true)),  Left('_err_'));
-    t.deepEqual(trippleFnLeft.pipe(Right(2))    .pipe(Right('hi')) .pipe(Left('err3')), Left('_err_'));
-    t.deepEqual(trippleFnLeft.pipe(Right(2))    .pipe(Right('hi')) .pipe(Right(true)),  Left('_err_'));
-
-    t.deepEqual(trippleFnRight.pipe(Left('err1')).pipe(Left('err2')).pipe(Left('err3')), Left('err1'));
-    t.deepEqual(trippleFnRight.pipe(Left('err1')).pipe(Left('err2')).pipe(Right(true)),  Left('err1'));
-    t.deepEqual(trippleFnRight.pipe(Left('err1')).pipe(Right('hi')) .pipe(Left('err3')), Left('err1'));
-    t.deepEqual(trippleFnRight.pipe(Left('err1')).pipe(Right('hi')) .pipe(Right(true)),  Left('err1'));
-    t.deepEqual(trippleFnRight.pipe(Right(2))    .pipe(Left('err2')).pipe(Left('err3')), Left('err2'));
-    t.deepEqual(trippleFnRight.pipe(Right(2))    .pipe(Left('err2')).pipe(Right(true)),  Left('err2'));
-    t.deepEqual(trippleFnRight.pipe(Right(2))    .pipe(Right('hi')) .pipe(Left('err3')), Left('err3'));
-    t.deepEqual(trippleFnRight.pipe(Right(2))    .pipe(Right('hi')) .pipe(Right(true)),  Right('hi'));
-    t.deepEqual(trippleFnRight.pipe(Right(2))    .pipe(Right('hi')) .pipe(Right(false)), Right('_4'));
-
-    const _5 /* Either<string, boolean> */ = Either.fromNullable('err', (a: number) => a > 0).pipe(Right(2));
-    t.deepEqual(_5, Right(true), 'Either.fromNullable is piping');
-
-    const _6 /* Either<string, boolean> */ = Either.fromMaybe('err', Maybe.Just((a: number) => a > 0)).pipe(Right(-2));
-    t.deepEqual(_6, Right(false), 'Either.fromMaybe is piping');
-
-    const _7 /* Either<never, boolean> */  = Right(2).map(a => (b: number) => a - b > 0).pipe(Right(3));
-    t.deepEqual(_7, Right(false), 'Either.prototype.map is piping');
-
-    const _8 /* Either<never, boolean> */ = Right(2).chain(a => Right((b: number) => a > b)).pipe(Right(3));
-    t.deepEqual(_8, Right(false), 'Either.prototype.chain is piping');
-
-    const _9 /* Either<never, boolean> */ = Right(4).ap(Right((a: number) => (b: number) => a > b)).pipe(Right(3));
-    t.deepEqual(_9, Right(true), 'Either.prototype.ap is piping');
-});
-
 test('Either.prototype.mapBoth()', t => {
     const _1 /* Either<boolean, boolean> */ = Left('err').mapBoth(err => err === 'err', (a: number) => a > 0);
     t.deepEqual(_1, Left(true));

--- a/test/Either.test.ts
+++ b/test/Either.test.ts
@@ -1,14 +1,7 @@
 import test from 'ava';
 
-import {
-    Nothing,
-    Just
-} from '../src/Maybe';
-import {
-    Either,
-    Left,
-    Right
-} from '../src/Either';
+import { Nothing, Just } from '../src/Maybe';
+import Either, { Left, Right } from '../src/Either';
 
 test('Either.fromNullable()', t => {
     const e1: Either<string, never> = Either.fromNullable('err', undefined);
@@ -167,41 +160,41 @@ test('Either.props()', t => {
     );
 });
 
-test('Either.sequence()', t => {
+test('Either.combine()', t => {
     t.deepEqual(
-        Either.sequence([]),
+        Either.combine([]),
         Right([])
     );
 
     t.deepEqual(
-        Either.sequence([ Left('1') ]),
+        Either.combine([ Left('1') ]),
         Left('1')
     );
 
     t.deepEqual(
-        Either.sequence([ Right(1) ]),
+        Either.combine([ Right(1) ]),
         Right([ 1 ])
     );
 
     t.deepEqual(
-        Either.sequence([ Left('1'), Left('2') ]),
+        Either.combine([ Left('1'), Left('2') ]),
         Left('1')
     );
 
     t.deepEqual(
-        Either.sequence([ Left('1'), Right(2) ]),
+        Either.combine([ Left('1'), Right(2) ]),
         Left('1')
     );
 
     t.deepEqual(
-        Either.sequence([ Right(1), Left('2') ]),
+        Either.combine([ Right(1), Left('2') ]),
         Left('2')
     );
 
     const array = [ Right(1), Right(2) ];
 
     t.deepEqual(
-        Either.sequence(array),
+        Either.combine(array),
         Right([ 1, 2 ])
     );
 
@@ -383,14 +376,14 @@ test('Either.prototype.pipe()', t => {
     );
 });
 
-test('Either.prototype.bimap()', t => {
+test('Either.prototype.mapBoth()', t => {
     t.deepEqual(
-        Left('err').bimap(err => err === 'err', a => '_' + a * 2),
+        Left('err').mapBoth(err => err === 'err', a => '_' + a * 2),
         Left(true)
     );
 
     t.deepEqual(
-        Right(1).bimap(err => err + '_', a => '_' + a * 2),
+        Right(1).mapBoth(err => err + '_', a => '_' + a * 2),
         Right('_2')
     );
 });

--- a/test/Either.test.ts
+++ b/test/Either.test.ts
@@ -1,146 +1,157 @@
 import test from 'ava';
 
-import { Nothing, Just } from '../src/Maybe';
+import Maybe from '../src/Maybe';
 import Either, { Left, Right } from '../src/Either';
 
 test('Either.fromNullable()', t => {
-    const e1: Either<string, never> = Either.fromNullable('err', undefined);
-    const e2: Either<string, never> = Either.fromNullable('err', null);
-    const e3: Either<string, number> = Either.fromNullable('err', 0);
-    const e4: Either<string, string> = Either.fromNullable('err', 'str');
-    const e5: Either<string, boolean> = Either.fromNullable('err', true);
-    const e6: Either<string, number> = Either.fromNullable('err', null);
-    const e7: Either<string, boolean> = Either.fromNullable('err', null);
+    const _1 /* Either<string, never> */ = Either.fromNullable('err', undefined);
+    t.deepEqual(_1, Left('err'));
 
-    t.deepEqual(e1, Left('err'));
-    t.deepEqual(e2, Left('err'));
-    t.deepEqual(e3, Right(0));
-    t.deepEqual(e4, Right('str'));
-    t.deepEqual(e5, Right(true));
-    t.deepEqual(e6, Left('err'));
-    t.deepEqual(e7, Left('err'));
+    const _2 /* Either<string, never> */ = Either.fromNullable('err', null);
+    t.deepEqual(_2, Left('err'));
+
+    const _3 /* Either<string, number> */ = Either.fromNullable('err', 0);
+    t.deepEqual(_3, Right(0));
+
+    const _4 /* Either<string, string> */ = Either.fromNullable('err', 'str');
+    t.deepEqual(_4, Right('str'));
+
+    const _5 /* Either<string, boolean> */ = Either.fromNullable('err', true);
+    t.deepEqual(_5, Right(true));
+
+    const _6: /* cast */ Either<string, number> = Either.fromNullable('err', null);
+    t.deepEqual(_6, Left('err'));
+
+    const _7: /* cast */ Either<string, boolean> = Either.fromNullable('err', null);
+    t.deepEqual(_7, Left('err'));
 });
 
 test('Either.fromMaybe()', t => {
-    t.deepEqual(
-        Either.fromMaybe('err', Nothing),
-        Left('err')
-    );
+    const _1 /* Either<string, never> */ = Either.fromMaybe('err', Maybe.Nothing);
+    t.deepEqual(_1, Left('err'));
 
-    t.deepEqual(
-        Either.fromMaybe('err', Just(1)),
-        Right(1)
-    );
+    const _2 /* Either<string, number> */ = Either.fromMaybe('err', Maybe.Just(1));
+    t.deepEqual(_2, Right(1));
+
+    const _3: /* cast */ Either<string, number> = Either.fromMaybe('err', Maybe.Nothing);
+    t.deepEqual(_3, Left('err'));
 });
 
 test('Either.props()', t => {
-    t.deepEqual(
-        Either.props({}),
-        Right({})
-    );
+    const _1 /* Either<never, {}> */ = Either.props({});
+    t.deepEqual(_1, Right({}));
 
-    t.deepEqual(
-        Either.props({
-            foo: Left('err')
-        }),
-        Left('err')
-    );
+    const _2 /* Either<string, {
+        foo: never;
+    }> */ = Either.props({
+        foo: Left('err')
+    });
+    t.deepEqual(_2, Left('err'));
 
+    const _3 /* Either<never, {
+        foo: number;
+    }> */ = Either.props({
+        foo: Right(1)
+    });
     t.deepEqual(
-        Either.props({
-            foo: Right(1)
-        }),
+        _3,
         Right({
             foo: 1
         })
     );
 
-    t.deepEqual(
-        Either.props({
-            foo: Left('err1'),
-            bar: Left('err2')
-        }),
-        Left('err1')
-    );
+    const _4 /* Either<string, {
+        foo: never;
+        bar: never;
+    }> */ = Either.props({
+        foo: Left('err1'),
+        bar: Left(1)
+    });
+    t.deepEqual(_4, Left('err1'));
 
-    t.deepEqual(
-        Either.props({
-            foo: Left('err'),
-            bar: Right(1)
-        }),
-        Left('err')
-    );
+    const _5 /* Either<string, {
+        foo: never;
+        bar: number;
+    }> */ = Either.props({
+        foo: Left('err'),
+        bar: Right(1)
+    });
+    t.deepEqual(_5, Left('err'));
 
-    t.deepEqual(
-        Either.props({
-            foo: Right(1),
-            bar: Left('err')
-        }),
-        Left('err')
-    );
+    const _6 /* Either<string, {
+        foo: number;
+        bar: never;
+    }> */ = Either.props({
+        foo: Right(1),
+        bar: Left('err')
+    });
+    t.deepEqual(_6, Left('err'));
 
+    const _7 /* Either<never, {
+        foo: string;
+        bar: number;
+    }> */ = Either.props({
+        foo: Right('foo'),
+        bar: Right(1)
+    });
     t.deepEqual(
-        Either.props({
-            foo: Right('foo'),
-            bar: Right(1)
-        }),
+        _7,
         Right({
             foo: 'foo',
             bar: 1
         })
     );
 
-    t.deepEqual(
-        Either.props({
-            foo: Left('err'),
-            bar: Right(1)
-        }).map(obj => obj.foo),
-        Left('err')
-    );
+    const _8 /* Either<string, never> */ = Either.props({
+        foo: Left('err'),
+        bar: Right(1)
+    }).map(obj => obj.foo);
+    t.deepEqual(_8, Left('err'));
 
-    t.deepEqual(
-        Either.props({
-            foo: Left('err'),
-            bar: Right(1)
-        }).map(obj => obj.bar),
-        Left('err')
-    );
+    const _9 /* Either<string, number> */ = Either.props({
+        foo: Left('err'),
+        bar: Right(1)
+    }).map(obj => obj.bar);
+    t.deepEqual(_9, Left('err'));
 
-    t.deepEqual(
-        Either.props({
-            foo: Right('foo'),
-            bar: Right(1)
-        }).map(obj => obj.foo),
-        Right('foo')
-    );
+    const _10 /* Either<never, string> */ = Either.props({
+        foo: Right('foo'),
+        bar: Right(1)
+    }).map(obj => obj.foo);
+    t.deepEqual(_10, Right('foo'));
 
-    t.deepEqual(
-        Either.props({
-            foo: Right('foo'),
-            bar: Right(1)
-        }).map(obj => obj.bar),
-        Right(1)
-    );
+    const _11 /* Either<never, number> */ = Either.props({
+        foo: Right('foo'),
+        bar: Right(1)
+    }).map(obj => obj.bar);
+    t.deepEqual(_11, Right(1));
 
-    t.deepEqual(
-        Either.props({
-            foo: Right('foo'),
-            bar: Either.props({
-                baz: Left('err')
-            })
-        }),
-        Left('err')
-    );
+    const _12 /* Either<string, {
+        foo: string;
+        bar: {
+            baz: never;
+        };
+    }> */ = Either.props({
+        foo: Right('foo'),
+        bar: Either.props({
+            baz: Left('err')
+        })
+    });
+    t.deepEqual(_12, Left('err'));
 
-    const shape = {
+    const _13 /* Either<never, {
+        foo: string;
+        bar: {
+            baz: number;
+        };
+    }> */ = Either.props({
         foo: Right('foo'),
         bar: Either.props({
             baz: Right(1)
         })
-    };
-
+    });
     t.deepEqual(
-        Either.props(shape),
+        _13,
         Right({
             foo: 'foo',
             bar: {
@@ -148,61 +159,29 @@ test('Either.props()', t => {
             }
         })
     );
-
-    t.deepEqual(
-        shape,
-        {
-            foo: Right('foo'),
-            bar: Either.props({
-                baz: Right(1)
-            })
-        }
-    );
 });
 
 test('Either.combine()', t => {
-    t.deepEqual(
-        Either.combine([]),
-        Right([])
-    );
+    const _1 /* Either<never, never[]> */ = Either.combine([]);
+    t.deepEqual(_1, Right([]));
 
-    t.deepEqual(
-        Either.combine([ Left('1') ]),
-        Left('1')
-    );
+    const _2 /* Either<string, never[]> */ = Either.combine([ Left('1') ]);
+    t.deepEqual(_2, Left('1'));
 
-    t.deepEqual(
-        Either.combine([ Right(1) ]),
-        Right([ 1 ])
-    );
+    const _3 /* Either<never, number[]> */ = Either.combine([ Right(1) ]);
+    t.deepEqual(_3, Right([ 1 ]));
 
-    t.deepEqual(
-        Either.combine([ Left('1'), Left('2') ]),
-        Left('1')
-    );
+    const _4 /* Either<string, never[]> */ = Either.combine([ Left('1'), Left('') ]);
+    t.deepEqual(_4, Left('1'));
 
-    t.deepEqual(
-        Either.combine([ Left('1'), Right(2) ]),
-        Left('1')
-    );
+    const _5 /* Either<string, number[]> */ = Either.combine([ Left('1'), Right(2) ]);
+    t.deepEqual(_5, Left('1'));
 
-    t.deepEqual(
-        Either.combine([ Right(1), Left('2') ]),
-        Left('2')
-    );
+    const _6 /* Either<string, number[]> */ = Either.combine([ Right(1), Left('2') ]);
+    t.deepEqual(_6, Left('2'));
 
-    const array = [ Right(1), Right(2) ];
-
-    t.deepEqual(
-        Either.combine(array),
-        Right([ 1, 2 ])
-    );
-
-    t.deepEqual(
-        array,
-        [ Right(1), Right(2) ],
-        'checking of Array immutability'
-    );
+    const _7 /* Either<never, number[]> */ = Either.combine([ Right(1), Right(2) ]);
+    t.deepEqual(_7, Right([ 1, 2 ]));
 });
 
 test('Either.prototype.isLeft()', t => {
@@ -244,84 +223,56 @@ test('Either.prototype.isEqual()', t => {
 });
 
 test('Either.prototype.map()', t => {
-    t.deepEqual(
-        Nothing.map(a => '_' + a * 2),
-        Nothing
-    );
+    const _1 /* Either<string, boolean> */ = Left('err').map((a: number) => a > 0);
+    t.deepEqual(_1, Left('err'));
 
-    t.deepEqual(
-        Just(1).map(a => '_' + a * 2),
-        Just('_2')
-    );
+    const _2 /* Either<never, boolean> */ = Right(1).map(a => a > 0);
+    t.deepEqual(_2, Right(true));
 });
 
 test('Either.prototype.chain()', t => {
-    t.deepEqual(
-        Left('err1').chain(() => Left('err2')),
-        Left('err1')
-    );
+    const _1 /* Either<string, never> */ = Left('err1').chain(() => Left('err2'));
+    t.deepEqual(_1, Left('err1'));
 
-    t.deepEqual(
-        Right(1).chain(() => Left('err')),
-        Left('err')
-    );
+    const _2 /* Either<string, number> */ = Right(1).chain(() => Left('err'));
+    t.deepEqual(_2, Left('err'));
 
-    t.deepEqual(
-        Left('err').chain(a => Right('_' + a * 2)),
-        Left('err')
-    );
+    const _3 /* Either<string, boolean> */ = Left('err').chain(a => Right(a > 0));
+    t.deepEqual(_3, Left('err'));
 
-    t.deepEqual(
-        Right(1).chain(a => Right('_' + a * 2)),
-        Right('_2')
-    );
+    const _4 /* Either<never, boolean> */ = Right(1).chain(a => Right(a > 0));
+    t.deepEqual(_4, Right(true));
 });
 
 test('Either.prototype.ap()', t => {
-    t.deepEqual(
-        Left('1').ap(Left('2')),
-        Left('1')
-    );
+    const _1 /* Either<string, never> */ = Left('1').ap(Left('2'));
+    t.deepEqual(_1, Left('1'));
 
-    t.deepEqual(
-        Left('1').ap(Right((a: number) => a * 2)),
-        Left('1')
-    );
+    const _2 /* Either<string, boolean> */ = Left('1').ap(Right((a: number) => a > 0));
+    t.deepEqual(_2, Left('1'));
 
-    t.deepEqual(
-        Right(1).ap(Left('1')),
-        Left('1')
-    );
+    const _3 /* Either<string, number> */ = Right(1).ap(Left('1'));
+    t.deepEqual(_3, Left('1'));
 
-    t.deepEqual(
-        Right(1).ap(Right((a: number) => a * 2)),
-        Right(2)
-    );
+    const _4 /* Either<never, boolean> */ = Right(1).ap(Right((a: number) => a > 0));
+    t.deepEqual(_4, Right(true));
 });
 
 test('Either.prototype.pipe()', t => {
     const fnLeft: Either<string, (a: number) => string> = Left('_err_');
-    const fnRight = Right((a: number) => '_' + a * 2);
+    const fnRight = Right((a: number) => a > 0);
 
-    t.deepEqual(
-        fnLeft.pipe(Left('err1')),
-        Left('_err_')
-    );
+    const _1 /* Either<string, string> */ = fnLeft.pipe(Left('err1'));
+    t.deepEqual(_1, Left('_err_'));
 
-    t.deepEqual(
-        fnLeft.pipe(Right(2)),
-        Left('_err_')
-    );
+    const _2 /* Either<string, string> */ = fnLeft.pipe(Right(2));
+    t.deepEqual(_2, Left('_err_'));
 
-    t.deepEqual(
-        fnRight.pipe(Left('err1')),
-        Left('err1')
-    );
+    const _3 /* Either<string, boolean> */ = fnRight.pipe(Left('err1'));
+    t.deepEqual(_3, Left('err1'));
 
-    t.deepEqual(
-        fnRight.pipe(Right(2)),
-        Right('_4')
-    );
+    const _4 /* Either<never, boolean> */ = fnRight.pipe(Right(2));
+    t.deepEqual(_4, Right(true));
 
     const trippleFnLeft: Either<string, (a: number) => (b: string) => (c: boolean) => string> = Left('_err_');
     const trippleFnRight = Right((a: number) => (b: string) => (c: boolean) => c ? b : '_' + a * 2);
@@ -345,145 +296,97 @@ test('Either.prototype.pipe()', t => {
     t.deepEqual(trippleFnRight.pipe(Right(2))    .pipe(Right('hi')) .pipe(Right(true)),  Right('hi'));
     t.deepEqual(trippleFnRight.pipe(Right(2))    .pipe(Right('hi')) .pipe(Right(false)), Right('_4'));
 
-    t.deepEqual(
-        Either.fromNullable('err', (a: number) => '_' + a * 2).pipe(Right(2)),
-        Right('_4'),
-        'Either.fromNullable is piping'
-    );
+    const _5 /* Either<string, boolean> */ = Either.fromNullable('err', (a: number) => a > 0).pipe(Right(2));
+    t.deepEqual(_5, Right(true), 'Either.fromNullable is piping');
 
-    t.deepEqual(
-        Either.fromMaybe('err', Just((a: number) => '_' + a * 2)).pipe(Right(2)),
-        Right('_4'),
-        'Either.fromMaybe is piping'
-    );
+    const _6 /* Either<string, boolean> */ = Either.fromMaybe('err', Maybe.Just((a: number) => a > 0)).pipe(Right(-2));
+    t.deepEqual(_6, Right(false), 'Either.fromMaybe is piping');
 
-    t.deepEqual(
-        Right(2).map(a => (b: number) => '_' + a * b).pipe(Right(3)),
-        Right('_6'),
-        'Either.prototype.map is piping'
-    );
+    const _7 /* Either<never, boolean> */  = Right(2).map(a => (b: number) => a - b > 0).pipe(Right(3));
+    t.deepEqual(_7, Right(false), 'Either.prototype.map is piping');
 
-    t.deepEqual(
-        Right(2).chain(a => Right((b: number) => '_' + a * b)).pipe(Right(3)),
-        Right('_6'),
-        'Either.prototype.chain is piping'
-    );
+    const _8 /* Either<never, boolean> */ = Right(2).chain(a => Right((b: number) => a > b)).pipe(Right(3));
+    t.deepEqual(_8, Right(false), 'Either.prototype.chain is piping');
 
-    t.deepEqual(
-        Right(2).ap(Right((a: number) => (b: number) => '_' + a * b)).pipe(Right(3)),
-        Right('_6'),
-        'Either.prototype.ap is piping'
-    );
+    const _9 /* Either<never, boolean> */ = Right(4).ap(Right((a: number) => (b: number) => a > b)).pipe(Right(3));
+    t.deepEqual(_9, Right(true), 'Either.prototype.ap is piping');
 });
 
 test('Either.prototype.mapBoth()', t => {
-    t.deepEqual(
-        Left('err').mapBoth(err => err === 'err', a => '_' + a * 2),
-        Left(true)
-    );
+    const _1 /* Either<boolean, boolean> */ = Left('err').mapBoth(err => err === 'err', (a: number) => a > 0);
+    t.deepEqual(_1, Left(true));
 
-    t.deepEqual(
-        Right(1).mapBoth(err => err + '_', a => '_' + a * 2),
-        Right('_2')
-    );
+    const _2 /* Either<string, boolean> */ = Right(1).mapBoth((err: string) => err + '_', a => a > 0);
+    t.deepEqual(_2, Right(true));
 });
 
 test('Either.prototype.swap()', t => {
-    t.deepEqual(
-        Left('err').swap(),
-        Right('err')
-    );
+    const _1 /* Either<never, string> */ = Left('err').swap();
+    t.deepEqual(_1, Right('err'));
 
-    t.deepEqual(
-        Right(1).swap(),
-        Left(1)
-    );
+    const _2 /* Either<number, never> */ = Right(1).swap();
+    t.deepEqual(_2, Left(1));
+
+    const _3 /* Either<number, string> */ = Right(1).orElse(() => Left('err')).swap();
+    t.deepEqual(_3, Left(1));
 });
 
 test('Either.prototype.mapLeft()', t => {
-    t.deepEqual(
-        Left('err').mapLeft(err => err === 'err'),
-        Left(true)
-    );
+    const _1 /* Either<boolean, never> */ = Left('err').mapLeft(err => err === 'err');
+    t.deepEqual(_1, Left(true));
 
-    t.deepEqual(
-        Right(1).mapLeft(err => err === 'err'),
-        Right(1)
-    );
+    const _2 /* Either<boolean, number> */ = Right(1).mapLeft((err: string) => err === 'err');
+    t.deepEqual(_2, Right(1));
 });
 
 test('Either.prototype.orElse()', t => {
-    t.deepEqual(
-        Left('err').orElse(err => Left(err + '_')),
-        Left('err_')
-    );
+    const _1 /* Either<string, never> */ = Left('err').orElse(err => Left(err + '_'));
+    t.deepEqual(_1, Left('err_'));
 
-    t.deepEqual(
-        Right(1).orElse(err => Left(err + '_')),
-        Right(1)
-    );
+    const _2 /* Either<string, number> */ = Right(1).orElse((err: string) => Left(err + '_'));
+    t.deepEqual(_2, Right(1));
 
-    t.deepEqual(
-        Left('err').orElse(() => Right(1)),
-        Right(1)
-    );
+    const _3 /* Either<string, number> */ = Left('err').orElse(() => Right(1));
+    t.deepEqual(_3, Right(1));
 
-    t.deepEqual(
-        Right(1).orElse(() => Right(2)),
-        Right(1)
-    );
+    const _4 /* Either<never, number> */ = Right(1).orElse(() => Right(2));
+    t.deepEqual(_4, Right(1));
 });
 
 test('Either.prototype.getOrElse()', t => {
-    t.is(
-        Left('err').getOrElse(1),
-        1
-    );
+    const _1 /* number */ = Left('err').getOrElse(1 * 1);
+    t.is(_1, 1);
 
-    t.is(
-        Right(2).getOrElse(1),
-        2
-    );
+    const _2 /* number */ = Right(2).getOrElse(1);
+    t.is(_2, 2);
 });
 
 test('Either.prototype.fold()', t => {
-    t.deepEqual(
-        Left('err').fold(err => err + '_', a => '_' + a * 2),
-        'err_'
-    );
+    const _1 /* string */ = Left('err').fold(err => err + '_', (a: number) => '_' + a * 2);
+    t.deepEqual(_1, 'err_');
 
-    t.deepEqual(
-        Right(2).fold(err => err + '_', a => '_' + a * 2),
-        '_4'
-    );
+    const _2 /* string */ = Right(2).fold(err => err + '_', (a: number) => '_' + a * 2);
+    t.deepEqual(_2, '_4');
 });
 
 test('Either.prototype.cata()', t => {
-    t.is(
-        Left('err').cata({
-            Left: err => err + '_',
-            Right: a => '_' + a * 2
-        }),
-        'err_'
-    );
+    const _1 /* string */ = Left('err').cata({
+        Left: err => err + '_',
+        Right: (a: number) => '_' + a * 2
+    });
+    t.is(_1, 'err_');
 
-    t.is(
-        Right(2).cata({
-            Left: err => err + '_',
-            Right: a => '_' + a * 2
-        }),
-        '_4'
-    );
+    const _2 /* string */ = Right(2).cata({
+        Left: (err: string) => err + '_',
+        Right: a => '_' + a * 2
+    });
+    t.is(_2, '_4');
 });
 
 test('Either.prototype.toMaybe()', t => {
-    t.deepEqual(
-        Left('err').toMaybe(),
-        Nothing
-    );
+    const _1 /* Maybe<never> */ = Left('err').toMaybe();
+    t.deepEqual(_1, Maybe.Nothing);
 
-    t.deepEqual(
-        Right(1).toMaybe(),
-        Just(1)
-    );
+    const _2 /* Maybe<number> */ = Right(1).toMaybe();
+    t.deepEqual(_2, Maybe.Just(1));
 });

--- a/test/Either.test.ts
+++ b/test/Either.test.ts
@@ -184,6 +184,20 @@ test('Either.combine()', t => {
     t.deepEqual(_7, Right([ 1, 2 ]));
 });
 
+test('Either.merge()', t => {
+    const _1 /* string */ = Either.merge(Left('err'));
+    t.deepEqual(_1, 'err');
+
+    const _2 /* number */ = Either.merge(Right(1));
+    t.deepEqual(_2, 1);
+
+    const _3 /* string */ = Either.merge(Left('err').orElse(() => Right('ok')));
+    t.deepEqual(_3, 'ok');
+
+    const _4 /* string */ = Left('err').orElse(() => Right('ok')).touch(Either.merge);
+    t.deepEqual(_4, 'ok');
+});
+
 test('Either.prototype.isLeft()', t => {
     t.true(Left('err').isLeft());
 


### PR DESCRIPTION
Updates: 
- `Either.list` → `Either.combine`
- \- `Either.prototype.pipe`
- \+ `Maybe.merge`
- \+ `Maybe.prototype.pipe<R>(fn: (either: Either<E, T>) => R): R`
- `Either` jsdocs added
- Iterating of `Either.combine` and `Either.props` optimised.