### PR TITLE
Json/Encode refactoring

### DIFF
--- a/src/Basics.ts
+++ b/src/Basics.ts
@@ -18,10 +18,34 @@ export type Cata<O extends {[ K in keyof O ]: (...args: Array<unknown>) => unkno
     : never
     ;
 
-export const identity = <T>(value: T): T => value;
+export function identity<T>(value: T): T {
+    return value;
+}
 
-export const inst = <T>(Constructor: new () => T) => new Constructor();
+export function inst<T>(Constructor: new () => T) {
+    return new Constructor();
+}
 
-export const cons = <A extends Array<unknown>, T>(
-    Constructor: new (...args: A) => A extends [] ? never : T
-) => (...args: A): T => new Constructor(...args);
+export function cons<A extends Array<unknown>, T>(Constructor: new (...args: A) => A extends [] ? never : T) {
+    return (...args: A): T => new Constructor(...args);
+}
+
+export function isString(value: unknown): value is string {
+    return typeof value === 'string';
+}
+
+export function isNumber(value: unknown): value is number {
+    return typeof value === 'number';
+}
+
+export function isBoolean(value: unknown): value is boolean {
+    return typeof value === 'boolean';
+}
+
+export function isArray(input: unknown): input is Array<unknown> {
+    return input instanceof Array;
+}
+
+export function isObject(input: unknown): input is {[ key: string ]: unknown } {
+    return typeof input === 'object' && input !== null && !isArray(input);
+}

--- a/src/Http.ts
+++ b/src/Http.ts
@@ -253,7 +253,7 @@ export const emptyBody: Body = PhantomBody.of(Nothing);
 
 export const stringBody = (type: string, value: string): Body => PhantomBody.of(Just({ type, value }));
 
-export const jsonBody = (encoder: Encode.Encoder): Body => stringBody('application/json', encoder.encode(4));
+export const jsonBody = (encoder: Encode.Encode): Body => stringBody('application/json', encoder.encode(4));
 
 /* R E Q U E S T */
 
@@ -294,7 +294,7 @@ export class Request<T> {
         return this.withBody(stringBody(type, value));
     }
 
-    public withJsonBody(encoder: Encode.Encoder): Request<T> {
+    public withJsonBody(encoder: Encode.Encode): Request<T> {
         return this.withBody(jsonBody(encoder));
     }
 

--- a/src/Http.ts
+++ b/src/Http.ts
@@ -10,7 +10,7 @@ import {
     Cmd
 } from './Platform/Cmd';
 import * as Decode from './Json/Decode';
-import * as Encode from './Json/Encode';
+import Encode from './Json/Encode';
 
 /* H E L P E R S */
 
@@ -253,7 +253,7 @@ export const emptyBody: Body = PhantomBody.of(Nothing);
 
 export const stringBody = (type: string, value: string): Body => PhantomBody.of(Just({ type, value }));
 
-export const jsonBody = (encoder: Encode.Encode): Body => stringBody('application/json', encoder.encode(4));
+export const jsonBody = (encoder: Encode.Value): Body => stringBody('application/json', encoder.encode(4));
 
 /* R E Q U E S T */
 
@@ -294,7 +294,7 @@ export class Request<T> {
         return this.withBody(stringBody(type, value));
     }
 
-    public withJsonBody(encoder: Encode.Encode): Request<T> {
+    public withJsonBody(encoder: Encode.Value): Request<T> {
         return this.withBody(jsonBody(encoder));
     }
 

--- a/src/Json/Encode.ts
+++ b/src/Json/Encode.ts
@@ -1,92 +1,139 @@
 import Maybe from '../Maybe';
 
-interface ValueArray extends Array<Value> {}
+interface ValueArray extends Array<Encode.Value> {}
 
-export type Value
-    = null
-    | string
-    | boolean
-    | number
-    | ValueArray
-    | {[ key: string ]: Value }
-    ;
+export namespace Encode {
+    export type Value
+        = null
+        | string
+        | boolean
+        | number
+        | ValueArray
+        | {[ key: string ]: Value }
+        ;
+}
 
-export abstract class Encoder {
+export abstract class Encode {
+    public static get nill(): Encode {
+        return Primitive.NULL;
+    }
+
+    public static string(string: string): Encode {
+        return new Primitive(string);
+    }
+
+    public static number(number: number): Encode {
+        return new Primitive(number);
+    }
+
+    public static boolean(boolean: boolean): Encode {
+        return new Primitive(boolean);
+    }
+
+    public static nullable<T>(encoder: (value: T) => Encode, maybe: Maybe<T>): Encode {
+        return maybe.map(encoder).getOrElse(Encode.nill);
+    }
+
+    public static list(encoders: Array<Encode>): Encode;
+    public static list<T>(encoder: (value: T) => Encode, values: Array<T>): Encode;
+    public static list<T>(encoderOrEncoders: Array<Encode> | ((value: T) => Encode), values?: Array<T>): Encode {
+        if (Array.isArray(encoderOrEncoders)) {
+            return new List(encoderOrEncoders);
+        }
+
+        const encoders: Array<Encode> = [];
+
+        for (const value of values as Array<T>) {
+            encoders.push(encoderOrEncoders(value));
+        }
+
+        return new List(encoders);
+    }
+
+    public static object(object: {[ key: string ]: Encode }): Encode;
+    // tslint:disable-next-line:unified-signatures
+    public static object(list: Array<[ string, Encode ]>): Encode;
+    public static object(config: Array<[ string, Encode ]> | {[ key: string ]: Encode }): Encode {
+        if (!Array.isArray(config)) {
+            return new Obj(config);
+        }
+
+        const config_: {[ key: string ]: Encode } = {};
+
+        for (const [ key, encode ] of config) {
+            config_[ key ] = encode;
+        }
+
+        return new Obj(config_);
+    }
+
     public encode(indent: number): string {
         return JSON.stringify(this.serialize(), null, indent);
     }
 
-    public abstract serialize(): Value;
+    public abstract serialize(): Encode.Value;
 }
 
-namespace Encode {
-    export class Primitive<T extends null | string | boolean | number> extends Encoder {
-        constructor(private readonly primitive: T) {
-            super();
-        }
+class Primitive<T extends null | string | boolean | number> extends Encode {
+    public static readonly NULL: Encode = new Primitive(null);
 
-        public serialize(): T {
-            return this.primitive;
-        }
+    constructor(private readonly primitive: T) {
+        super();
     }
 
-    export class List extends Encoder {
-        constructor(private readonly array: Array<Encoder>) {
-            super();
-        }
-
-        public serialize(): Array<Value> {
-            const result: Array<Value> = [];
-
-            for (const value of this.array) {
-                result.push(value.serialize());
-            }
-
-            return result;
-        }
-    }
-
-    export class Object extends Encoder {
-        constructor(private readonly object: {[ key: string ]: Encoder}) {
-            super();
-        }
-
-        public serialize(): {[ key: string ]: Value } {
-            const result: {[ key: string ]: Value } = {};
-
-            for (const key in this.object) {
-                if (this.object.hasOwnProperty(key)) {
-                    result[ key ] = this.object[ key ].serialize();
-                }
-            }
-
-            return result;
-        }
+    public serialize(): Encode.Value {
+        return this.primitive;
     }
 }
 
-export const nill: Encoder = new Encode.Primitive(null);
-
-export const string = (string: string): Encoder => new Encode.Primitive(string);
-export const number = (number: number): Encoder => new Encode.Primitive(number);
-export const boolean = (boolean: boolean): Encoder => new Encode.Primitive(boolean);
-
-export const nullable = <T>(encoder: (value: T) => Encoder, maybe: Maybe<T>): Encoder => {
-    return maybe.map(encoder).getOrElse(nill);
-};
-
-export const list = (array: Array<Encoder>): Encoder => new Encode.List(array);
-
-export const listOf = <T>(encoder: (value: T) => Encoder, array: Array<T>): Encoder => {
-    const result: Array<Encoder> = [];
-
-    for (const value of array) {
-        result.push(encoder(value));
+class List extends Encode {
+    constructor(private readonly array: Array<Encode>) {
+        super();
     }
 
-    return list(result);
-};
+    public serialize(): Encode.Value {
+        const result: Array<Encode.Value> = [];
 
-export const object = <T extends {[ key: string ]: Encoder }>(object: T): Encoder => {
-    return new Encode.Object(object);
-};
+        for (const value of this.array) {
+            result.push(value.serialize());
+        }
+
+        return result;
+    }
+}
+
+class Obj extends Encode {
+    constructor(private readonly object: {[ key: string ]: Encode }) {
+        super();
+    }
+
+    public serialize(): {[ key: string ]: Encode.Value } {
+        const result: {[ key: string ]: Encode.Value } = {};
+
+        for (const key in this.object) {
+            if (this.object.hasOwnProperty(key)) {
+                result[ key ] = this.object[ key ].serialize();
+            }
+        }
+
+        return result;
+    }
+}
+
+export type Value = Encode.Value;
+
+export const nill = Encode.nill;
+
+export const string = Encode.string;
+
+export const number = Encode.number;
+
+export const boolean = Encode.boolean;
+
+export const nullable = Encode.nullable;
+
+export const list = Encode.list;
+
+export const object = Encode.object;
+
+export default Encode;

--- a/src/Json/Encode.ts
+++ b/src/Json/Encode.ts
@@ -1,3 +1,6 @@
+import {
+    isArray
+} from '../Basics';
 import Maybe from '../Maybe';
 
 export namespace Encode {
@@ -62,7 +65,7 @@ export function object(list: Array<[ string, Value ]>): Value;
 export function object(listOrObject: Array<[ string, Value ]> | {[ key: string ]: Value }): Value {
     const acc: {[ key: string ]: unknown } = {};
 
-    if (Array.isArray(listOrObject)) {
+    if (isArray(listOrObject)) {
         for (const [ key, value ] of listOrObject) {
             acc[ key ] = value.serialize();
         }

--- a/src/Maybe.ts
+++ b/src/Maybe.ts
@@ -24,7 +24,9 @@ export abstract class Maybe<T> {
     /**
      * Represents a `Maybe` containing no value.
      */
-    public static Nothing: Maybe<never>;
+    public static get Nothing(): Maybe<never> {
+        return Variants.Nothing.SINGLETON;
+    }
 
     /**
      * Constructs a `Maybe` containing the `value`.
@@ -356,6 +358,8 @@ export abstract class Maybe<T> {
 
 namespace Variants {
     export class Nothing extends Maybe<never> {
+        public static readonly SINGLETON: Maybe<never> = new Nothing();
+
         public isNothing(): boolean {
             return true;
         }
@@ -396,8 +400,6 @@ namespace Variants {
             return super.cata(pattern);
         }
     }
-
-    Maybe.Nothing = new Nothing();
 
     export class Just<T> extends Maybe<T> {
         public constructor(private readonly value: T) {

--- a/test/Json/Encode.test.ts
+++ b/test/Json/Encode.test.ts
@@ -76,7 +76,7 @@ test('Json.Encode.nullable()', t => {
     );
 });
 
-test('Json.Encode.list()', t => {
+test('Json.Encode.list(encoders)', t => {
     t.is(
         Encode.list([
             Encode.number(1),
@@ -145,14 +145,14 @@ test('Json.Encode.list()', t => {
 });
 
 
-test('Json.Encode.listOf()', t => {
+test('Json.Encode.list(encoder, values)', t => {
     t.is(
-        Encode.listOf(Encode.number, [ 1, 2, 1 ]).encode(0),
+        Encode.list(Encode.number, [ 1, 2, 1 ]).encode(0),
         '[1,2,1]'
     );
 
     t.deepEqual(
-        Encode.listOf(Encode.number, [ 1, 2, 1 ]).serialize(),
+        Encode.list(Encode.number, [ 1, 2, 1 ]).serialize(),
         [ 1, 2, 1 ]
     );
 });
@@ -164,7 +164,7 @@ test('Json.Encode.object()', t => {
         foo: boolean;
     }
 
-    const encoder1 = (foo: Foo): Encode.Encoder => Encode.object({
+    const encoder1 = (foo: Foo): Encode.Encode => Encode.object({
         _bar: Encode.string(foo.bar),
         _baz: Encode.number(foo.baz),
         _foo: Encode.boolean(foo.foo)

--- a/test/Json/Encode.test.ts
+++ b/test/Json/Encode.test.ts
@@ -1,10 +1,7 @@
 import test from 'ava';
 
-import {
-    Nothing,
-    Just
-} from '../../src/Maybe';
-import * as Encode from '../../src/Json/Encode';
+import Maybe from '../../src/Maybe';
+import { Encode } from '../../src/Json/Encode';
 
 test('Json.Encode.nill', t => {
     t.is(
@@ -56,22 +53,22 @@ test('Json.Encode.boolean()', t => {
 
 test('Json.Encode.nullable()', t => {
     t.is(
-        Encode.nullable(Encode.string, Nothing).encode(0),
+        Encode.nullable(Encode.string, Maybe.Nothing).encode(0),
         'null'
     );
 
     t.is(
-        Encode.nullable(Encode.string, Nothing).serialize(),
+        Encode.nullable(Encode.string, Maybe.Nothing).serialize(),
         null
     );
 
     t.is(
-        Encode.nullable(Encode.string, Just('msg')).encode(0),
+        Encode.nullable(Encode.string, Maybe.Just('msg')).encode(0),
         '"msg"'
     );
 
     t.is(
-        Encode.nullable(Encode.string, Just('msg')).serialize(),
+        Encode.nullable(Encode.string, Maybe.Just('msg')).serialize(),
         'msg'
     );
 });
@@ -144,7 +141,6 @@ test('Json.Encode.list(encoders)', t => {
     );
 });
 
-
 test('Json.Encode.list(encoder, values)', t => {
     t.is(
         Encode.list(Encode.number, [ 1, 2, 1 ]).encode(0),
@@ -157,26 +153,37 @@ test('Json.Encode.list(encoder, values)', t => {
     );
 });
 
-test('Json.Encode.object()', t => {
-    interface Foo {
+test('Json.Encode.object(object)', t => {
+    const _1 = (foo: {
         bar: string;
         baz: number;
         foo: boolean;
-    }
-
-    const encoder1 = (foo: Foo): Encode.Encode => Encode.object({
+    }): Encode => Encode.object({
         _bar: Encode.string(foo.bar),
         _baz: Encode.number(foo.baz),
         _foo: Encode.boolean(foo.foo)
     });
 
     t.is(
-        encoder1({
+        _1({
             bar: 'str',
             baz: 0,
             foo: false
         }).encode(0),
         '{"_bar":"str","_baz":0,"_foo":false}'
+    );
+
+    t.is(
+        _1({
+            bar: 'str',
+            baz: 0,
+            foo: false
+        }).encode(4),
+        '{\n'
+        + '    "_bar": "str",\n'
+        + '    "_baz": 0,\n'
+        + '    "_foo": false\n'
+        + '}'
     );
 
     t.is(
@@ -217,9 +224,30 @@ test('Json.Encode.object()', t => {
         }).encode(0),
         '{"foo":0,"bar":[false,"1"]}'
     );
+});
+
+test('Json.Encode.object(list)', t => {
+    const _1 = (foo: {
+        bar: string;
+        baz: number;
+        foo: boolean;
+    }): Encode => Encode.object([
+        [ '_bar', Encode.string(foo.bar) ],
+        [ '_baz', Encode.number(foo.baz) ],
+        [ '_foo', Encode.boolean(foo.foo) ]
+    ]);
 
     t.is(
-        encoder1({
+        _1({
+            bar: 'str',
+            baz: 0,
+            foo: false
+        }).encode(0),
+        '{"_bar":"str","_baz":0,"_foo":false}'
+    );
+
+    t.is(
+        _1({
             bar: 'str',
             baz: 0,
             foo: false
@@ -229,5 +257,59 @@ test('Json.Encode.object()', t => {
         + '    "_baz": 0,\n'
         + '    "_foo": false\n'
         + '}'
+    );
+
+    t.is(
+        Encode.object([
+            [
+                'foo',
+                Encode.object([
+                    [
+                        'bar',
+                        Encode.object([
+                            [ 'baz', Encode.number(0) ]
+                        ])
+                    ]
+                ])
+            ]
+        ]).encode(0),
+        '{"foo":{"bar":{"baz":0}}}'
+    );
+
+    t.deepEqual(
+        Encode.object([
+            [
+                'foo',
+                Encode.object([
+                    [
+                        'bar',
+                        Encode.object([
+                            [ 'baz', Encode.number(0) ]
+                        ])
+                    ]
+                ])
+            ]
+        ]).serialize(),
+        {
+            foo: {
+                bar: {
+                    baz: 0
+                }
+            }
+        }
+    );
+
+    t.is(
+        Encode.object([
+            [ 'foo', Encode.number(0) ],
+            [
+                'bar',
+                Encode.list([
+                    Encode.boolean(false),
+                    Encode.string('1')
+                ])
+            ]
+        ]).encode(0),
+        '{"foo":0,"bar":[false,"1"]}'
     );
 });

--- a/test/Json/Encode.test.ts
+++ b/test/Json/Encode.test.ts
@@ -1,7 +1,7 @@
 import test from 'ava';
 
 import Maybe from '../../src/Maybe';
-import { Encode } from '../../src/Json/Encode';
+import Encode from '../../src/Json/Encode';
 
 test('Json.Encode.nill', t => {
     t.is(
@@ -158,7 +158,7 @@ test('Json.Encode.object(object)', t => {
         bar: string;
         baz: number;
         foo: boolean;
-    }): Encode => Encode.object({
+    }): Encode.Value => Encode.object({
         _bar: Encode.string(foo.bar),
         _baz: Encode.number(foo.baz),
         _foo: Encode.boolean(foo.foo)
@@ -231,7 +231,7 @@ test('Json.Encode.object(list)', t => {
         bar: string;
         baz: number;
         foo: boolean;
-    }): Encode => Encode.object([
+    }): Encode.Value => Encode.object([
         [ '_bar', Encode.string(foo.bar) ],
         [ '_baz', Encode.number(foo.baz) ],
         [ '_foo', Encode.boolean(foo.foo) ]


### PR DESCRIPTION
- Make `Value` as `Encoder`
- Remove `Encoder` from exports
- Make exports more "greedy"
- merge `listOf` and `list`
- add `object` from list of pairs